### PR TITLE
Point refactor#140

### DIFF
--- a/app/components/dem-info.jsx
+++ b/app/components/dem-info.jsx
@@ -1,36 +1,34 @@
 'use strict'
-import React from 'react';
-import cx from 'classnames';
-import insertSheet from 'react-jss';
-
+import React from 'react'
+import cx from 'classnames'
+import insertSheet from 'react-jss'
 
 function DemInfo(props) {
-    const { user, classes, className, ...otherProps } = props;
+  const { state, dob, party, classes, className, ...otherProps } = props
+  if (!(state && dob && party)) return null // if no data, render not
 
-    const userState = user?.state || '';
-    const userAge = user?.dob ? calculateAge(user.dob) : '';
-    const userPoliticalParty = user?.party || '';
+  const userState = state || ''
+  const userAge = dob ? calculateAge(dob) : ''
+  const userPoliticalParty = party || ''
 
+  let contentText = ''
+  if (userPoliticalParty && (userAge || userState)) {
+    contentText += `${userPoliticalParty} | `
+  } else if (userPoliticalParty) {
+    contentText += `${userPoliticalParty}`
+  }
 
-    let contentText = '';
-    if (userPoliticalParty && (userAge || userState)) {
-        contentText += `${userPoliticalParty} | `;
-    } else if (userPoliticalParty) {
-        contentText += `${userPoliticalParty}`;
-    }
+  if (userAge && userState) {
+    contentText += `${userAge}, ${userState}`
+  } else if (userAge || userState) {
+    contentText += userAge || userState
+  }
 
-    if (userAge && userState) {
-        contentText += `${userAge}, ${userState}`;
-    } else if (userAge || userState) {
-        contentText += userAge || userState;
-    }
-
-
-    return (
-        <span className={cx(classes.infoText, className)} {...otherProps}>
-            {contentText}
-        </span>
-    )
+  return (
+    <span className={cx(classes.infoText, className)} {...otherProps}>
+      {contentText}
+    </span>
+  )
 }
 
 /**
@@ -39,30 +37,28 @@ function DemInfo(props) {
  * @return {Number} age (in years)
  */
 function calculateAge(birthdayStr) {
-    const birthday = new Date(birthdayStr)
-    const today = new Date()
-    let age = today.getFullYear() - birthday.getFullYear();
-    const month = today.getMonth() - birthday.getMonth();
+  const birthday = new Date(birthdayStr)
+  const today = new Date()
+  let age = today.getFullYear() - birthday.getFullYear()
+  const month = today.getMonth() - birthday.getMonth()
 
-    if (month < 0 || (month === 0 && today.getDate() < birthday.getDate())) {
-        age--;
-    }
+  if (month < 0 || (month === 0 && today.getDate() < birthday.getDate())) {
+    age--
+  }
 
-    return age
-
+  return age
 }
 
 const demInfoStyles = {
-    infoText: {
-        fontFamily: 'Inter',
-        fontSize: '1rem',
-        fontWeight: '400',
-        lineHeight: '1.5rem',
-        letterSpacing: '0rem',
-        textAlign: 'left',
-        color: '#5D5D5C'
-    }
+  infoText: {
+    fontFamily: 'Inter',
+    fontSize: '1rem',
+    fontWeight: '400',
+    lineHeight: '1.5rem',
+    letterSpacing: '0rem',
+    textAlign: 'left',
+    color: '#5D5D5C',
+  },
 }
-
 
 export default insertSheet(demInfoStyles)(DemInfo)

--- a/app/components/grouping-step.jsx
+++ b/app/components/grouping-step.jsx
@@ -79,7 +79,7 @@ export default function GroupingStep(props) {
     setGs(oldGs => {
       let pointsToGroup = [...oldGs.pointsToGroup]
       let yourGroups = [...oldGs.yourGroups]
-      for (const point of value.removedPointObjs || []) {
+      for (const point of value.removedPointDocs || []) {
         // leave it in the yourGroups
         if (oldGs.yourGroupsSelected.some(p => p._id === point._id)) {
           yourGroups.push(point)
@@ -87,8 +87,8 @@ export default function GroupingStep(props) {
         // move it back to the ungrouped points
         else pointsToGroup.push(point)
       }
-      if (value.pointObj) {
-        yourGroups.push(value.pointObj)
+      if (value.pointDoc) {
+        yourGroups.push(value.pointDoc)
         // we have to change it because the new one may have different children
       }
       shared.groupedPointList = pointsToGroup.concat(yourGroups) // shareing this data with other components
@@ -104,32 +104,32 @@ export default function GroupingStep(props) {
       let pointsToGroup = [...oldGs.pointsToGroup]
       let yourGroups = [...oldGs.yourGroups]
       let selectedPoints = [...oldGs.selectedPoints]
-      for (const point of value.removedPointObjs || []) {
+      for (const point of value.removedPointDocs || []) {
         // move it back to the ungrouped points
         pointsToGroup.push(point)
         yourGroups = yourGroups.filter(p => p._id !== point._id)
         selectedPoints = selectedPoints.filter(id => id !== point._id)
       }
       // it doeosn't create a new pointObj, but it delete it, or change the existing one.
-      if (value.pointObj) {
-        if (!value.pointObj.groupedPoints?.length) {
+      if (value.pointDoc) {
+        if (!value.pointDoc.groupedPoints?.length) {
           // user has ungrouped this point
-          if ((index = yourGroups.findIndex(p => value.pointObj._id === p._id)) >= 0) {
+          if ((index = yourGroups.findIndex(p => value.pointDoc._id === p._id)) >= 0) {
             yourGroups.splice(index, 1)
-            pointsToGroup.push(value.pointObj)
+            pointsToGroup.push(value.pointDoc)
           }
-          selectedPoints = selectedPoints.filter(id => id !== value.pointObj._id)
-        } else if (yourGroups.some(p => p._id === value.pointObj._id)) {
+          selectedPoints = selectedPoints.filter(id => id !== value.pointDoc._id)
+        } else if (yourGroups.some(p => p._id === value.pointDoc._id)) {
           //do nothing
         } else {
           // lead point is changed - find the old one
           index = yourGroups.findIndex(p => p.groupedPoints.some(p => p._id === value.pointObj._id))
           if (index >= 0) {
             yourGroups.splice(index, 1)
-            yourGroups.push(value.pointObj)
+            yourGroups.push(value.pointDoc)
           } else {
-            console.info("got new pointObj don't know why")
-            yourGroups.push(value.pointObj)
+            console.info("got new pointDoc don't know why")
+            yourGroups.push(value.pointDoc)
           }
         }
       }

--- a/app/components/grouping-step.jsx
+++ b/app/components/grouping-step.jsx
@@ -7,7 +7,6 @@
 import React, { useState } from 'react'
 import { createUseStyles } from 'react-jss'
 import cx from 'classnames'
-import Point from './point'
 import PointGroup from './point-group'
 import { PrimaryButton, SecondaryButton } from './button'
 import StatusBadge from './status-badge'
@@ -172,14 +171,14 @@ export default function GroupingStep(props) {
       </div>
       {gs.selectLead != null ? (
         <div className={classes.selectLead}>
-          <PointGroup point={<Point point={gs.selectLead} />} vState={'selectLead'} onDone={onSelectLeadDone} />
+          <PointGroup pointDoc={gs.selectLead} vState={'selectLead'} onDone={onSelectLeadDone} />
         </div>
       ) : null}
       <div className={classes.groupsContainer}>
         {gs.pointsToGroup.map(point => (
           <PointGroup
             key={point._id}
-            point={<Point point={point} />}
+            pointDoc={point}
             vState="default"
             select={gs.selectedPoints.some(id => id === point._id)}
             onClick={() => togglePointSelection(point._id)}
@@ -195,7 +194,7 @@ export default function GroupingStep(props) {
                 <PointGroup
                   className={classes.yourGroupsPoint}
                   key={point._id}
-                  point={<Point point={point} />}
+                  pointDoc={point}
                   vState="editable"
                   select={gs.selectedPoints.some(id => id === point._id)}
                   onClick={() => togglePointSelection(point._id)}

--- a/app/components/grouping-step.jsx
+++ b/app/components/grouping-step.jsx
@@ -7,6 +7,7 @@
 import React, { useState } from 'react'
 import { createUseStyles } from 'react-jss'
 import cx from 'classnames'
+import Point from './point'
 import PointGroup from './point-group'
 import { PrimaryButton, SecondaryButton } from './button'
 import StatusBadge from './status-badge'
@@ -171,14 +172,14 @@ export default function GroupingStep(props) {
       </div>
       {gs.selectLead != null ? (
         <div className={classes.selectLead}>
-          <PointGroup pointObj={gs.selectLead} vState={'selectLead'} onDone={onSelectLeadDone} />
+          <PointGroup point={<Point point={gs.selectLead} />} vState={'selectLead'} onDone={onSelectLeadDone} />
         </div>
       ) : null}
       <div className={classes.groupsContainer}>
         {gs.pointsToGroup.map(point => (
           <PointGroup
             key={point._id}
-            pointObj={point}
+            point={<Point point={point} />}
             vState="default"
             select={gs.selectedPoints.some(id => id === point._id)}
             onClick={() => togglePointSelection(point._id)}
@@ -194,7 +195,7 @@ export default function GroupingStep(props) {
                 <PointGroup
                   className={classes.yourGroupsPoint}
                   key={point._id}
-                  pointObj={point}
+                  point={<Point point={point} />}
                   vState="editable"
                   select={gs.selectedPoints.some(id => id === point._id)}
                   onClick={() => togglePointSelection(point._id)}

--- a/app/components/pair-compare.jsx
+++ b/app/components/pair-compare.jsx
@@ -1,282 +1,315 @@
 // https://github.com/EnCiv/civil-pursuit/issues/53
 
 'use strict'
-import React, { useEffect, useRef, useState } from 'react';
-import Point from './point.jsx';
-import { createUseStyles } from 'react-jss';
-import { SecondaryButton } from './button.jsx';
+import React, { useEffect, useRef, useState } from 'react'
+import Point from './point'
+import { createUseStyles } from 'react-jss'
+import { SecondaryButton } from './button.jsx'
 
 function PairCompare(props) {
-    const { pointList = [], onDone = () => { }, mainPoint = { subject: "", description: "" }, ...otherProps } = props
+  const { pointList = [], onDone = () => {}, mainPoint = { subject: '', description: '' }, ...otherProps } = props
 
-    // idxLeft and idxRight can swap places at any point - they are simply pointers to the current two <Point/> elements
-    const [idxLeft, setIdxLeft] = useState(0);
-    const [idxRight, setIdxRight] = useState(1);
+  // idxLeft and idxRight can swap places at any point - they are simply pointers to the current two <Point/> elements
+  const [idxLeft, setIdxLeft] = useState(0)
+  const [idxRight, setIdxRight] = useState(1)
 
-    const isInitialRender = useRef(true);
+  const isInitialRender = useRef(true)
 
-    const visibleRightPointRef = useRef(null);
-    const visibleLeftPointRef = useRef(null);
-    const hiddenLeftPointRef = useRef(null);
-    const hiddenRightPointRef = useRef(null);
+  const visibleRightPointRef = useRef(null)
+  const visibleLeftPointRef = useRef(null)
+  const hiddenLeftPointRef = useRef(null)
+  const hiddenRightPointRef = useRef(null)
 
-    const [pointsIdxCounter, setPointsIdxCounter] = useState(1);
-    const [selectedPoint, setSelectedPoint] = useState(null);
-    const [isRightTransitioning, setIsRightTransitioning] = useState(false);
-    const [isLeftTransitioning, setIsLeftTransitioning] = useState(false);
-    const classes = useStyles();
+  const [pointsIdxCounter, setPointsIdxCounter] = useState(1)
+  const [selectedPoint, setSelectedPoint] = useState(null)
+  const [isRightTransitioning, setIsRightTransitioning] = useState(false)
+  const [isLeftTransitioning, setIsLeftTransitioning] = useState(false)
+  const classes = useStyles()
 
-    useEffect(() => {
-        if (isSelectionComplete()) {
-            setSelectedPoint(pointList[idxLeft] ? pointList[idxLeft] : pointList[idxRight]);
-        }
-    }, [pointsIdxCounter])
+  useEffect(() => {
+    if (isSelectionComplete()) {
+      setSelectedPoint(pointList[idxLeft] ? pointList[idxLeft] : pointList[idxRight])
+    }
+  }, [pointsIdxCounter])
 
-    useEffect(() => {
-        if (isInitialRender.current) {
-            isInitialRender.current = false;
-            return
-        }
-
-        if (selectedPoint) {
-            onDone({ valid: true, value: selectedPoint });
-        } else {
-            onDone({ valid: false, value: null })
-        }
-    }, [selectedPoint])
-
-    const handleLeftPointClick = () => {
-
-        // prevent transitions from firing on last comparison
-        if (idxRight >= pointList.length - 1 || idxLeft >= pointList.length - 1) {
-            if (idxLeft >= idxRight) {
-                setIdxRight(idxLeft + 1)
-            } else {
-                setIdxRight(idxRight + 1)
-            }
-            setPointsIdxCounter(pointsIdxCounter + 1)
-            return
-        }
-
-        setIsLeftTransitioning(true)
-        const visiblePointRight = visibleRightPointRef.current
-        const hiddenPointRight = hiddenRightPointRef.current
-
-        Object.assign(visiblePointRight.style, { position: 'relative', transform: 'translateX(200%)', transition: 'transform 0.5s linear' });
-        Object.assign(hiddenPointRight.style, { position: 'absolute', transform: 'translateY(8.25rem)', transition: 'transform 0.5s linear' });
-
-
-        setTimeout(() => {
-            setIsLeftTransitioning(false);
-            if (idxLeft >= idxRight) {
-                setIdxRight(idxLeft + 1);
-            } else {
-                setIdxRight(idxRight + 1);
-            }
-
-            setPointsIdxCounter(pointsIdxCounter + 1);
-
-            Object.assign(visiblePointRight.style, { position: '', transition: 'none', transform: '' });
-            Object.assign(hiddenPointRight.style, { position: '', transition: 'none', transform: '' });
-
-        }, 500);
-
+  useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false
+      return
     }
 
-    const handleRightPointClick = () => {
+    if (selectedPoint) {
+      onDone({ valid: true, value: selectedPoint })
+    } else {
+      onDone({ valid: false, value: null })
+    }
+  }, [selectedPoint])
 
-        // prevent transitions from firing on last comparison
-        if (idxRight >= pointList.length - 1 || idxLeft >= pointList.length - 1) {
-            if (idxLeft >= idxRight) {
-                setIdxLeft(idxLeft + 1)
-            } else {
-                setIdxLeft(idxRight + 1)
-            }
-            setPointsIdxCounter(pointsIdxCounter + 1)
-            return
-        }
-
-        setIsRightTransitioning(true)
-        const visiblePointLeft = visibleLeftPointRef.current;
-        const hiddenPointLeft = hiddenLeftPointRef.current;
-
-        Object.assign(visiblePointLeft.style, { position: 'relative', transform: 'translateX(-200%)', transition: 'transform 0.5s linear' });
-        Object.assign(hiddenPointLeft.style, { position: 'absolute', transform: 'translateY(8.25rem)', transition: 'transform 0.5s linear' });
-
-
-        setTimeout(() => {
-            setIsRightTransitioning(false)
-            if (idxLeft >= idxRight) {
-                setIdxLeft(idxLeft + 1)
-            } else {
-                setIdxLeft(idxRight + 1)
-            }
-
-            setPointsIdxCounter(pointsIdxCounter + 1)
-
-            Object.assign(visiblePointLeft.style, { position: '', transition: 'none', transform: '' });
-            Object.assign(hiddenPointLeft.style, { position: '', transition: 'none', transform: '' });
-
-        }, 500);
-
+  const handleLeftPointClick = () => {
+    // prevent transitions from firing on last comparison
+    if (idxRight >= pointList.length - 1 || idxLeft >= pointList.length - 1) {
+      if (idxLeft >= idxRight) {
+        setIdxRight(idxLeft + 1)
+      } else {
+        setIdxRight(idxRight + 1)
+      }
+      setPointsIdxCounter(pointsIdxCounter + 1)
+      return
     }
 
-    const handleNeitherButton = () => {
-        if (selectedPoint) return
+    setIsLeftTransitioning(true)
+    const visiblePointRight = visibleRightPointRef.current
+    const hiddenPointRight = hiddenRightPointRef.current
 
-        if (idxLeft >= idxRight) {
-            setIdxRight(idxLeft + 1)
-            setIdxLeft(idxLeft + 2)
-        } else {
-            setIdxLeft(idxRight + 1)
-            setIdxRight(idxRight + 2)
-        }
+    Object.assign(visiblePointRight.style, {
+      position: 'relative',
+      transform: 'translateX(200%)',
+      transition: 'transform 0.5s linear',
+    })
+    Object.assign(hiddenPointRight.style, {
+      position: 'absolute',
+      transform: 'translateY(8.25rem)',
+      transition: 'transform 0.5s linear',
+    })
 
-        setPointsIdxCounter(pointsIdxCounter + 2)
+    setTimeout(() => {
+      setIsLeftTransitioning(false)
+      if (idxLeft >= idxRight) {
+        setIdxRight(idxLeft + 1)
+      } else {
+        setIdxRight(idxRight + 1)
+      }
 
+      setPointsIdxCounter(pointsIdxCounter + 1)
+
+      Object.assign(visiblePointRight.style, { position: '', transition: 'none', transform: '' })
+      Object.assign(hiddenPointRight.style, { position: '', transition: 'none', transform: '' })
+    }, 500)
+  }
+
+  const handleRightPointClick = () => {
+    // prevent transitions from firing on last comparison
+    if (idxRight >= pointList.length - 1 || idxLeft >= pointList.length - 1) {
+      if (idxLeft >= idxRight) {
+        setIdxLeft(idxLeft + 1)
+      } else {
+        setIdxLeft(idxRight + 1)
+      }
+      setPointsIdxCounter(pointsIdxCounter + 1)
+      return
     }
 
-    const handleStartOverButton = () => {
-        onDone({ valid: false, value: null })
-        setIdxRight(1)
-        setIdxLeft(0)
-        setPointsIdxCounter(1)
-        setSelectedPoint(null)
+    setIsRightTransitioning(true)
+    const visiblePointLeft = visibleLeftPointRef.current
+    const hiddenPointLeft = hiddenLeftPointRef.current
+
+    Object.assign(visiblePointLeft.style, {
+      position: 'relative',
+      transform: 'translateX(-200%)',
+      transition: 'transform 0.5s linear',
+    })
+    Object.assign(hiddenPointLeft.style, {
+      position: 'absolute',
+      transform: 'translateY(8.25rem)',
+      transition: 'transform 0.5s linear',
+    })
+
+    setTimeout(() => {
+      setIsRightTransitioning(false)
+      if (idxLeft >= idxRight) {
+        setIdxLeft(idxLeft + 1)
+      } else {
+        setIdxLeft(idxRight + 1)
+      }
+
+      setPointsIdxCounter(pointsIdxCounter + 1)
+
+      Object.assign(visiblePointLeft.style, { position: '', transition: 'none', transform: '' })
+      Object.assign(hiddenPointLeft.style, { position: '', transition: 'none', transform: '' })
+    }, 500)
+  }
+
+  const handleNeitherButton = () => {
+    if (selectedPoint) return
+
+    if (idxLeft >= idxRight) {
+      setIdxRight(idxLeft + 1)
+      setIdxLeft(idxLeft + 2)
+    } else {
+      setIdxLeft(idxRight + 1)
+      setIdxRight(idxRight + 2)
     }
 
-    const isSelectionComplete = () => {
-        return pointsIdxCounter >= pointList.length
-    }
+    setPointsIdxCounter(pointsIdxCounter + 2)
+  }
 
-    const nextIndex = idxLeft > idxRight ? idxLeft + 1 : idxRight + 1
-    const hiddenEmptyLeftPoint = <Point ref={hiddenLeftPointRef} className={classes.emptyPoint} />
-    const hiddenTransitioningLeftPoint = <Point ref={hiddenLeftPointRef} className={classes.emptyPoint} subject={pointList[nextIndex]?.subject} description={pointList[nextIndex]?.description} />
-    const hiddenEmptyRightPoint = <Point ref={hiddenRightPointRef} className={classes.emptyPoint} />
-    const hiddenTransitioningRightPoint = <Point ref={hiddenRightPointRef} className={classes.emptyPoint} subject={pointList[nextIndex]?.subject} description={pointList[nextIndex]?.description} />
+  const handleStartOverButton = () => {
+    onDone({ valid: false, value: null })
+    setIdxRight(1)
+    setIdxLeft(0)
+    setPointsIdxCounter(1)
+    setSelectedPoint(null)
+  }
 
-    return (
-        <div className={classes.container} {...otherProps}>
+  const isSelectionComplete = () => {
+    return pointsIdxCounter >= pointList.length
+  }
 
-            <div className={classes.mainPointContainer}>
-                <div className={classes.mainPointSubject}>{mainPoint.subject}</div>
-                <div className={classes.mainPointDescription}>{mainPoint.description}</div>
+  const nextIndex = idxLeft > idxRight ? idxLeft + 1 : idxRight + 1
+  const hiddenEmptyLeftPoint = <Point ref={hiddenLeftPointRef} className={classes.emptyPoint} />
+  const hiddenTransitioningLeftPoint = (
+    <Point ref={hiddenLeftPointRef} className={classes.emptyPoint} point={pointList[nextIndex]} />
+  )
+  const hiddenEmptyRightPoint = <Point ref={hiddenRightPointRef} className={classes.emptyPoint} />
+  const hiddenTransitioningRightPoint = (
+    <Point ref={hiddenRightPointRef} className={classes.emptyPoint} point={pointList[nextIndex]} />
+  )
+
+  return (
+    <div className={classes.container} {...otherProps}>
+      <div className={classes.mainPointContainer}>
+        <div className={classes.mainPointSubject}>{mainPoint.subject}</div>
+        <div className={classes.mainPointDescription}>{mainPoint.description}</div>
+      </div>
+
+      <span className={isSelectionComplete() ? classes.statusBadgeComplete : classes.statusBadge}>{`${
+        pointsIdxCounter <= pointList.length ? pointsIdxCounter : pointList.length
+      } out of ${pointList.length}`}</span>
+
+      <div className={classes.lowerContainer}>
+        <div className={classes.hiddenPointContainer}>
+          {pointsIdxCounter < pointList.length && (
+            <div className={classes.hiddenPoint}>
+              {isRightTransitioning ? hiddenTransitioningLeftPoint : hiddenEmptyLeftPoint}
             </div>
-
-            <span className={isSelectionComplete() ? classes.statusBadgeComplete : classes.statusBadge}>{`${pointsIdxCounter <= pointList.length ? pointsIdxCounter : pointList.length} out of ${pointList.length}`}</span>
-
-            <div className={classes.lowerContainer}>
-
-                <div className={classes.hiddenPointContainer}>
-                    {pointsIdxCounter < pointList.length &&
-                        <div className={classes.hiddenPoint}>{isRightTransitioning ? hiddenTransitioningLeftPoint : hiddenEmptyLeftPoint}</div>}
-                    {pointsIdxCounter < pointList.length &&
-                        <div className={classes.hiddenPoint}>{isLeftTransitioning ? hiddenTransitioningRightPoint : hiddenEmptyRightPoint}</div>}
-                </div>
-
-                <div className={classes.visiblePointsContainer}>
-                    {idxLeft < pointList.length &&
-                        <button className={classes.visiblePoint} ref={visibleLeftPointRef} onClick={handleLeftPointClick} tabIndex={0} title={`Choose as more important: ${pointList[idxLeft]?.subject}`}>{<Point {...pointList[idxLeft]} />}</button>}
-                    {idxRight < pointList.length &&
-                        <button className={classes.visiblePoint} ref={visibleRightPointRef} onClick={handleRightPointClick} tabIndex={0} title={`Choose as more important: ${pointList[idxRight]?.subject}`} >{<Point {...pointList[idxRight]}/>}</button>}
-                </div>
-                <div className={classes.buttonsContainer}>
-                    {
-                        !isSelectionComplete() ?
-                            <SecondaryButton onDone={handleNeitherButton}>Neither</SecondaryButton>
-                            : <SecondaryButton onDone={handleStartOverButton}>Start Over</SecondaryButton>
-                    }
-                </div>
+          )}
+          {pointsIdxCounter < pointList.length && (
+            <div className={classes.hiddenPoint}>
+              {isLeftTransitioning ? hiddenTransitioningRightPoint : hiddenEmptyRightPoint}
             </div>
-
+          )}
         </div>
-    )
+
+        <div className={classes.visiblePointsContainer}>
+          {idxLeft < pointList.length && (
+            <button
+              className={classes.visiblePoint}
+              ref={visibleLeftPointRef}
+              onClick={handleLeftPointClick}
+              tabIndex={0}
+              title={`Choose as more important: ${pointList[idxLeft]?.subject}`}
+            >
+              {<Point point={pointList[idxLeft]} />}
+            </button>
+          )}
+          {idxRight < pointList.length && (
+            <button
+              className={classes.visiblePoint}
+              ref={visibleRightPointRef}
+              onClick={handleRightPointClick}
+              tabIndex={0}
+              title={`Choose as more important: ${pointList[idxRight]?.subject}`}
+            >
+              {<Point point={pointList[idxRight]} />}
+            </button>
+          )}
+        </div>
+        <div className={classes.buttonsContainer}>
+          {!isSelectionComplete() ? (
+            <SecondaryButton onDone={handleNeitherButton}>Neither</SecondaryButton>
+          ) : (
+            <SecondaryButton onDone={handleStartOverButton}>Start Over</SecondaryButton>
+          )}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 const useStyles = createUseStyles(theme => ({
-
-    container: {
-        fontFamily: theme.font.fontFamily,
-        overflowX: 'hidden',
+  container: {
+    fontFamily: theme.font.fontFamily,
+    overflowX: 'hidden',
+  },
+  statusBadge: {
+    backgroundColor: theme.colors.statusBadgeProgressBackground,
+    border: `${theme.border.width.thin} solid ${theme.colors.statusBadgeProgressBorder}`,
+    ...sharedStatusBadgeStyle(),
+  },
+  statusBadgeComplete: {
+    backgroundColor: theme.colors.statusBadgeCompletedBackground,
+    border: `${theme.border.width.thin} solid ${theme.colors.statusBadgeCompletedBorder}`,
+    ...sharedStatusBadgeStyle(),
+  },
+  mainPointContainer: {
+    textAlign: 'center',
+  },
+  mainPointSubject: {
+    fontWeight: '600',
+    fontSize: '1.5rem',
+    lineHeight: '2rem',
+  },
+  mainPointDescription: {
+    fontWeight: '400',
+  },
+  hiddenPointContainer: {
+    position: 'relative',
+    display: 'flex',
+    justifyContent: 'space-evenly',
+    overflow: 'visible',
+    paddingTop: '5rem',
+    marginBottom: '1rem',
+    clipPath: 'xywh(0 0 100% 500%)',
+  },
+  hiddenPoint: {
+    width: '30%',
+  },
+  emptyPoint: {
+    position: 'absolute',
+    width: '30%',
+    top: '-2rem',
+  },
+  visiblePointsContainer: {
+    display: 'flex',
+    justifyContent: 'space-evenly',
+    gap: '1rem',
+  },
+  visiblePoint: {
+    width: '30%',
+    cursor: 'pointer',
+    borderRadius: '0.9375rem',
+    '&:focus': {
+      outline: `${theme.focusOutline}`,
     },
-    statusBadge: {
-        backgroundColor: theme.colors.statusBadgeProgressBackground,
-        border: `${theme.border.width.thin} solid ${theme.colors.statusBadgeProgressBorder}`,
-        ...sharedStatusBadgeStyle()
-    },
-    statusBadgeComplete: {
-        backgroundColor: theme.colors.statusBadgeCompletedBackground,
-        border: `${theme.border.width.thin} solid ${theme.colors.statusBadgeCompletedBorder}`,
-        ...sharedStatusBadgeStyle()
-    },
-    mainPointContainer: {
-        textAlign: 'center',
-    },
-    mainPointSubject: {
-        fontWeight: '600',
-        fontSize: '1.5rem',
-        lineHeight: '2rem',
-    },
-    mainPointDescription: {
-        fontWeight: '400',
-    },
-    hiddenPointContainer: {
-        position: 'relative',
-        display: 'flex',
-        justifyContent: 'space-evenly',
-        overflow: 'visible',
-        paddingTop: '5rem',
-        marginBottom: '1rem',
-        clipPath: 'xywh(0 0 100% 500%)'
-    },
-    hiddenPoint: {
-        width: '30%',
-    },
-    emptyPoint: {
-        position: 'absolute',
-        width: '30%',
-        top: '-2rem',
-    },
-    visiblePointsContainer: {
-        display: 'flex',
-        justifyContent: 'space-evenly',
-        gap: '1rem',
-    },
-    visiblePoint: {
-        width: '30%',
-        cursor: 'pointer',
-        borderRadius: '0.9375rem',
-        '&:focus': {
-            outline: `${theme.focusOutline}`,
-        },
-        ...sharedButtonStyle(),
-    },
-    lowerContainer: {
-        marginTop: '1rem',
-        backgroundColor: theme.colors.cardOutline,
-        borderRadius: '1rem',
-        border: `${theme.border.width.thin} solid ${theme.colors.borderGray}`,
-    },
-    buttonsContainer: {
-        display: 'flex',
-        justifyContent: 'center',
-        margin: '2rem auto',
-    },
+    ...sharedButtonStyle(),
+  },
+  lowerContainer: {
+    marginTop: '1rem',
+    backgroundColor: theme.colors.cardOutline,
+    borderRadius: '1rem',
+    border: `${theme.border.width.thin} solid ${theme.colors.borderGray}`,
+  },
+  buttonsContainer: {
+    display: 'flex',
+    justifyContent: 'center',
+    margin: '2rem auto',
+  },
 }))
 
 const sharedStatusBadgeStyle = () => ({
-    borderRadius: '1rem',
-    padding: '0.375rem 0.625rem',
+  borderRadius: '1rem',
+  padding: '0.375rem 0.625rem',
 })
 
 const sharedButtonStyle = () => ({
+  background: 'none',
+  border: 'none',
+  padding: '0',
+  textAlign: 'left',
+  '&:hover': {
     background: 'none',
     border: 'none',
-    padding: '0',
-    textAlign: 'left',
-    '&:hover': {
-        background: 'none',
-        border: 'none',
-    }
+  },
 })
 
-export default PairCompare;
+export default PairCompare

--- a/app/components/point-group.jsx
+++ b/app/components/point-group.jsx
@@ -5,7 +5,7 @@
 import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
 import { createUseStyles } from 'react-jss'
-import Point from './point.jsx'
+import Point from './point'
 import SvgChevronUp from '../svgr/chevron-up'
 import SvgChevronDown from '../svgr/chevron-down'
 import SvgClose from '../svgr/close'
@@ -14,8 +14,7 @@ import DemInfo from './dem-info.jsx'
 
 // vState for Point: default, selected, disabled, collapsed
 const CreatePoint = (pointObj, vState, children, className) => {
-  const { subject, description } = pointObj
-  return <Point subject={subject} description={description} vState={vState} children={children} className={className} />
+  return <Point point={pointObj} vState={vState} children={children} className={className} />
 }
 
 const PointGroup = props => {
@@ -91,7 +90,6 @@ const PointGroup = props => {
                       point,
                       point._id === selected ? 'selected' : 'default',
                       [
-                        <DemInfo user={point.user} />,
                         <div className={classes.invisibleElement}>
                           {/* this is here to take up space for the heigth calculation of every grid cell, but not be visible */}
                           <ModifierButton children={'Select as Lead'} />
@@ -214,7 +212,6 @@ const PointGroup = props => {
                         point,
                         'default',
                         [
-                          <DemInfo user={point.user} />,
                           <div className={classes.pointBottomButtons}>
                             <div className={classes.pointWidthButton}>
                               <ModifierButton

--- a/app/components/point-group.jsx
+++ b/app/components/point-group.jsx
@@ -21,7 +21,7 @@ const PointGroup = props => {
   const [p, setPoint] = useState(point)
   const [expanded, setExpanded] = useState(vState === 'selectLead' || vState === 'edit')
   const classes = useStylesFromThemeFunction()
-  const { subject, description, user, groupedPoints } = p
+  const { subject, description, demInfo, groupedPoints } = p
   const soloPoint = p
   const singlePoint = !groupedPoints || groupedPoints.length === 0
   const [selected, setSelected] = useState('')
@@ -88,7 +88,7 @@ const PointGroup = props => {
               {groupedPoints?.map(point => {
                 const pointChildren = [
                   <div className={classes.invisibleElement}>
-                    {/* this is here to take up space for the heigth calculation of every grid cell, but not be visible */}
+                    {/* this is here to take up space for the height calculation of every grid cell, but not be visible */}
                     <ModifierButton children={'Select as Lead'} />
                   </div>,
                   <div className={classes.selectButtonRow}>
@@ -199,7 +199,7 @@ const PointGroup = props => {
           )}
           {subject && <div className={cx(classes.subjectStyle)}>{subject}</div>}
           {description && <div className={cx(classes.descriptionStyle)}>{description}</div>}
-          {user && <DemInfo user={user} />}
+          {demInfo && <DemInfo user={demInfo} />}
           {childrenWithProps}
           {vs === 'edit' && expanded && !singlePoint && (
             <div className={classes.defaultWidth}>

--- a/app/components/point-group.jsx
+++ b/app/components/point-group.jsx
@@ -71,7 +71,7 @@ const PointGroup = props => {
             <TextButton
               title="Ungroup and close"
               onClick={() => {
-                setPoint({})
+                setPoint(null)
                 onDone({
                   valid: true,
                   value: { point: undefined, removedPoints: groupedPoints },
@@ -146,7 +146,7 @@ const PointGroup = props => {
                     },
                     [undefined, []]
                   )
-                  const newPoint = <Point {...p} groupedPoints={g} />
+                  const newPoint = <Point point={p} groupedPoints={g} />
                   setPoint(newPoint)
                   onDone({
                     valid: true,
@@ -216,11 +216,16 @@ const PointGroup = props => {
                           onDone={() => {
                             const newPoint = (
                               <Point
-                                {...point}
-                                groupedPoints={[soloPoint, ...groupedPoints.filter((e, i) => i !== leadIndex)]}
+                                key={point._id}
+                                point={point}
+                                groupedPoints={[
+                                  <Point point={soloPoint} />,
+                                  ...groupedPoints
+                                    .filter((e, i) => i !== leadIndex)
+                                    .map(p => <Point key={p._id} point={p} />),
+                                ]}
                               />
                             )
-
                             setPoint(newPoint)
                             onDone({
                               valid: true,
@@ -238,9 +243,15 @@ const PointGroup = props => {
                           children="Remove from Group"
                           onDone={() => {
                             const newPoint = (
-                              <Point {...soloPoint} groupedPoints={groupedPoints.filter((e, i) => i !== leadIndex)} />
+                              <Point
+                                point={soloPoint}
+                                groupedPoints={[
+                                  ...groupedPoints
+                                    .filter((e, i) => i !== leadIndex)
+                                    .map(p => <Point key={p._id} point={p} />),
+                                ]}
+                              />
                             )
-
                             setPoint(newPoint)
                             onDone({
                               valid: true,
@@ -312,7 +323,7 @@ const PointGroup = props => {
                   title="Ungroup"
                   children="Ungroup"
                   onDone={() => {
-                    const newPoint = <Point {...soloPoint} groupedPoints={[]} />
+                    const newPoint = <Point point={soloPoint} groupedPoints={[]} />
 
                     setPoint(newPoint)
                     onDone({

--- a/app/components/point-group.jsx
+++ b/app/components/point-group.jsx
@@ -14,7 +14,7 @@ import DemInfo from './dem-info.jsx'
 
 // vState for Point: default, selected, disabled, collapsed
 const PointGroup = props => {
-  const { point, vState, select, className, onDone = () => {}, ...otherProps } = props
+  const { point, vState, select, children = [], className = '', onDone = () => {}, ...otherProps } = props
 
   // vState for pointGroup: ['default', 'edit', 'view', 'selectLead', 'collapsed']
   const [vs, setVState] = useState(vState === 'editable' ? 'edit' : vState)
@@ -34,6 +34,13 @@ const PointGroup = props => {
   const onMouseOut = () => {
     setIsHovered(false)
   }
+
+  const childrenWithProps = React.Children.map(children?.props?.children ?? children, child => {
+    return React.cloneElement(child, {
+      className: cx(child.props.className, { isHovered: isHovered }),
+      vState: vState,
+    })
+  })
 
   useEffect(() => {
     setVState(vState === 'editable' ? 'edit' : vState)
@@ -57,7 +64,6 @@ const PointGroup = props => {
           {subject && <div className={cx(classes.subjectStyle, classes.collapsedSubject)}>{subject}</div>}
         </div>
       )}
-
       {vs === 'selectLead' && (
         <div className={cx(classes.borderStyle, classes.contentContainer)}>
           <p className={classes.titleGroup}>Please select the response you want to lead with</p>
@@ -154,7 +160,6 @@ const PointGroup = props => {
           </div>
         </div>
       )}
-
       {vs !== 'collapsed' && vs !== 'selectLead' && (
         <div
           className={cx(classes.borderStyle, classes.contentContainer, classes.informationGrid, {
@@ -195,6 +200,7 @@ const PointGroup = props => {
           {subject && <div className={cx(classes.subjectStyle)}>{subject}</div>}
           {description && <div className={cx(classes.descriptionStyle)}>{description}</div>}
           {user && <DemInfo user={user} />}
+          {childrenWithProps}
           {vs === 'edit' && expanded && !singlePoint && (
             <div className={classes.defaultWidth}>
               {!singlePoint && <p className={classes.titleGroup}>Edit the response you'd like to lead with</p>}

--- a/app/components/point-group.jsx
+++ b/app/components/point-group.jsx
@@ -18,7 +18,10 @@ const PointGroup = props => {
 
   // vState for pointGroup: ['default', 'edit', 'view', 'selectLead', 'collapsed']
   const [vs, setVState] = useState(vState === 'editable' ? 'edit' : vState)
-  const [p, setPoint] = useState(point)
+
+  // This refers to a point object that's passed to the point property of the Point component
+  // It's different than the point component passed in
+  const [p, setPointDoc] = useState(point)
   const [expanded, setExpanded] = useState(vState === 'selectLead' || vState === 'edit')
   const classes = useStylesFromThemeFunction()
   const { subject, description, demInfo, groupedPoints } = p
@@ -47,7 +50,7 @@ const PointGroup = props => {
     setExpanded(vState === 'selectLead' || vState === 'edit')
   }, [vState]) // could be changed by parent component, or within this component
   useEffect(() => {
-    setPoint(point)
+    setPointDoc(point)
   }, [point]) // could be changed by parent component, or within this component
 
   return (
@@ -71,10 +74,10 @@ const PointGroup = props => {
             <TextButton
               title="Ungroup and close"
               onClick={() => {
-                setPoint(null)
+                setPointDoc({})
                 onDone({
                   valid: true,
-                  value: { point: undefined, removedPoints: groupedPoints },
+                  value: { pointDoc: undefined, removedPointDocs: groupedPoints },
                 })
               }}
             >
@@ -146,11 +149,14 @@ const PointGroup = props => {
                     },
                     [undefined, []]
                   )
-                  const newPoint = <Point point={p} groupedPoints={g} />
-                  setPoint(newPoint)
+                  const newPointDoc = {
+                    ...p,
+                    groupedPoints: g,
+                  } // This is a point object, not a component
+                  setPointDoc(newPointDoc)
                   onDone({
                     valid: true,
-                    value: { point: newPoint },
+                    value: { pointDoc: newPoint },
                   })
                   setVState('edit')
                   setExpanded(false)
@@ -214,22 +220,14 @@ const PointGroup = props => {
                           title={`Select as Lead: ${point.subject}`}
                           children="Select as Lead"
                           onDone={() => {
-                            const newPoint = (
-                              <Point
-                                key={point._id}
-                                point={point}
-                                groupedPoints={[
-                                  <Point point={soloPoint} />,
-                                  ...groupedPoints
-                                    .filter((e, i) => i !== leadIndex)
-                                    .map(p => <Point key={p._id} point={p} />),
-                                ]}
-                              />
-                            )
-                            setPoint(newPoint)
+                            const newPointDoc = {
+                              ...point,
+                              groupedPoints: [soloPoint, ...groupedPoints.filter((e, i) => i !== leadIndex)],
+                            } // This is a point object, not a component
+                            setPointDoc(newPointDoc)
                             onDone({
                               valid: true,
-                              value: { point: newPoint },
+                              value: { pointDoc: newPoint },
                             })
                           }}
                           disabled={false}
@@ -242,20 +240,14 @@ const PointGroup = props => {
                           title={`Remove from Group: ${point.subject}`}
                           children="Remove from Group"
                           onDone={() => {
-                            const newPoint = (
-                              <Point
-                                point={soloPoint}
-                                groupedPoints={[
-                                  ...groupedPoints
-                                    .filter((e, i) => i !== leadIndex)
-                                    .map(p => <Point key={p._id} point={p} />),
-                                ]}
-                              />
-                            )
-                            setPoint(newPoint)
+                            const newPointDoc = {
+                              ...soloPoint,
+                              groupedPoints: groupedPoints.filter((e, i) => i !== leadIndex),
+                            } // This is a point object, not a component
+                            setPointDoc(newPointDoc)
                             onDone({
                               valid: true,
-                              value: { point: newPoint, removedPoints: [point] },
+                              value: { pointDoc: newPoint, removedPointDocs: [point] },
                             })
                           }}
                         />
@@ -323,12 +315,14 @@ const PointGroup = props => {
                   title="Ungroup"
                   children="Ungroup"
                   onDone={() => {
-                    const newPoint = <Point point={soloPoint} groupedPoints={[]} />
-
-                    setPoint(newPoint)
+                    const newPointDoc = {
+                      ...soloPoint,
+                      groupedPoints: [],
+                    } // This is a point object, not a component
+                    setPointDoc(newPointDoc)
                     onDone({
                       valid: true,
-                      value: { point: newPoint, removedPoints: groupedPoints },
+                      value: { pointDoc: newPoint, removedPointDocs: groupedPoints },
                     })
                   }}
                 />

--- a/app/components/point-group.jsx
+++ b/app/components/point-group.jsx
@@ -21,11 +21,11 @@ const PointGroup = props => {
 
   // This refers to a point object that's passed to the point property of the Point component
   // It's different than the point component passed in
-  const [p, setPointDoc] = useState(point)
+  const [pD, setPointDoc] = useState(point.props.point)
   const [expanded, setExpanded] = useState(vState === 'selectLead' || vState === 'edit')
   const classes = useStylesFromThemeFunction()
-  const { subject, description, demInfo, groupedPoints } = p
-  const soloPoint = p
+  const { subject, description, demInfo, groupedPoints } = pD
+  const soloPoint = pD
   const singlePoint = !groupedPoints || groupedPoints.length === 0
   const [selected, setSelected] = useState('')
   const [isHovered, setIsHovered] = useState(false)
@@ -50,8 +50,8 @@ const PointGroup = props => {
     setExpanded(vState === 'selectLead' || vState === 'edit')
   }, [vState]) // could be changed by parent component, or within this component
   useEffect(() => {
-    setPointDoc(point)
-  }, [point]) // could be changed by parent component, or within this component
+    setPointDoc(point.props.point)
+  }, [point.props.point]) // could be changed by parent component, or within this component
 
   return (
     <div className={cx(className)} {...otherProps}>
@@ -89,6 +89,7 @@ const PointGroup = props => {
           {expanded && (
             <div className={classes.selectPointsContainer}>
               {groupedPoints?.map(point => {
+                const pointDoc = point.props.point
                 const pointChildren = [
                   <div className={classes.invisibleElement}>
                     {/* this is here to take up space for the height calculation of every grid cell, but not be visible */}
@@ -98,21 +99,21 @@ const PointGroup = props => {
                     {/* some grid cells will be taller than others, based on content. The real button is absolute positioned so they are all at the bottom of the grid cell
                           We welcome an alternative to positioning the select button at the bottom of the grid cell when a cell is shorter than others in the row */}
                     <ModifierButton
-                      className={cx(classes.selectSelectButton, point._id === selected && classes.selectedButton)}
-                      title={`Select as Lead: ${point.subject}`}
+                      className={cx(classes.selectSelectButton, pointDoc._id === selected && classes.selectedButton)}
+                      title={`Select as Lead: ${pointDoc.subject}`}
                       children="Select as Lead"
                       disabled={false}
                       disableOnClick={false}
                       onDone={() => {
-                        setSelected(point._id)
+                        setSelected(pointDoc._id)
                       }}
                     />
                   </div>,
                 ]
                 return (
-                  <div key={point._id} className={classes.selectPoints}>
+                  <div key={pointDoc._id} className={classes.selectPoints}>
                     <Point
-                      point={point}
+                      point={pointDoc}
                       _id={selected ? 'selected' : 'default'}
                       children={pointChildren}
                       className={cx(classes.selectPointsPassDown, classes.noBoxShadow)}
@@ -130,19 +131,19 @@ const PointGroup = props => {
                 children="Done"
                 onDone={() => {
                   const [p, g] = groupedPoints.reduce(
-                    ([p, g], point) => {
-                      if (point._id === selected) {
-                        p = point
+                    ([p, g], pointDoc) => {
+                      if (pointDoc._id === selected) {
+                        p = pointDoc
                         // need to flatten groupedPoints so children to not have children
-                        if (point.groupedPoints) {
-                          g.push(...point.groupedPoints)
+                        if (pointDoc.groupedPoints) {
+                          g.push(...pointDoc.groupedPoints)
                         }
                       } else {
-                        g.push(point)
+                        g.push(pointDoc)
                         // need to flatten groupedPoints so children to not have children
-                        if (point.groupedPoints) {
-                          g.push(...point.groupedPoints)
-                          delete point.groupedPoints
+                        if (pointDoc.groupedPoints) {
+                          g.push(...pointDoc.groupedPoints)
+                          delete pointDoc.groupedPoints
                         }
                       }
                       return [p, g]
@@ -156,7 +157,7 @@ const PointGroup = props => {
                   setPointDoc(newPointDoc)
                   onDone({
                     valid: true,
-                    value: { pointDoc: newPoint },
+                    value: { pointDoc: newPointDoc },
                   })
                   setVState('edit')
                   setExpanded(false)
@@ -212,22 +213,23 @@ const PointGroup = props => {
               {!singlePoint && <p className={classes.titleGroup}>Edit the response you'd like to lead with</p>}
               <div className={classes.selectPointsContainer}>
                 {groupedPoints.map((point, leadIndex) => {
+                  const pointDoc = point.props.point
                   const pointChildren = [
                     <div className={classes.pointBottomButtons}>
                       <div className={classes.pointWidthButton}>
                         <ModifierButton
                           className={classes.pointWidthButton}
-                          title={`Select as Lead: ${point.subject}`}
+                          title={`Select as Lead: ${pointDoc.subject}`}
                           children="Select as Lead"
                           onDone={() => {
                             const newPointDoc = {
-                              ...point,
+                              ...pointDoc,
                               groupedPoints: [soloPoint, ...groupedPoints.filter((e, i) => i !== leadIndex)],
                             } // This is a point object, not a component
                             setPointDoc(newPointDoc)
                             onDone({
                               valid: true,
-                              value: { pointDoc: newPoint },
+                              value: { pointDoc: newPointDoc },
                             })
                           }}
                           disabled={false}
@@ -237,7 +239,7 @@ const PointGroup = props => {
                       <div className={classes.pointWidthButton}>
                         <TextButton
                           className={classes.pointWidthButton}
-                          title={`Remove from Group: ${point.subject}`}
+                          title={`Remove from Group: ${pointDoc.subject}`}
                           children="Remove from Group"
                           onDone={() => {
                             const newPointDoc = {
@@ -247,7 +249,7 @@ const PointGroup = props => {
                             setPointDoc(newPointDoc)
                             onDone({
                               valid: true,
-                              value: { pointDoc: newPoint, removedPointDocs: [point] },
+                              value: { pointDoc: newPointDoc, removedPointDocs: [pointDoc] },
                             })
                           }}
                         />
@@ -255,9 +257,9 @@ const PointGroup = props => {
                     </div>,
                   ]
                   return (
-                    <div key={point._id} className={classes.selectPoints}>
+                    <div key={pointDoc._id} className={classes.selectPoints}>
                       <Point
-                        point={point}
+                        point={pointDoc}
                         children={pointChildren}
                         className={cx(classes.selectPointsPassDown, classes.noBoxShadow)}
                       />
@@ -272,9 +274,10 @@ const PointGroup = props => {
               {!singlePoint && <p className={classes.titleGroup}>Other Responses</p>}
               <div className={classes.selectPointsContainer}>
                 {groupedPoints.map(point => {
+                  const pointDoc = point.props.point
                   return (
-                    <div key={point._id} className={classes.selectPoints}>
-                      <Point point={point} className={cx(classes.selectPointsPassDown, classes.noBoxShadow)} />
+                    <div key={pointDoc._id} className={classes.selectPoints}>
+                      <Point point={pointDoc} className={cx(classes.selectPointsPassDown, classes.noBoxShadow)} />
                     </div>
                   )
                 })}
@@ -322,7 +325,7 @@ const PointGroup = props => {
                     setPointDoc(newPointDoc)
                     onDone({
                       valid: true,
-                      value: { pointDoc: newPoint, removedPointDocs: groupedPoints },
+                      value: { pointDoc: newPointDoc, removedPointDocs: groupedPoints },
                     })
                   }}
                 />

--- a/app/components/point-group.jsx
+++ b/app/components/point-group.jsx
@@ -21,8 +21,8 @@ const PointGroup = props => {
   const [p, setPoint] = useState(point)
   const [expanded, setExpanded] = useState(vState === 'selectLead' || vState === 'edit')
   const classes = useStylesFromThemeFunction()
-  console.log(p)
-  const { subject, description, user, groupedPoints, demInfo } = p
+  const { subject, description, user, groupedPoints } = p
+  const soloPoint = p
   const singlePoint = !groupedPoints || groupedPoints.length === 0
   const [selected, setSelected] = useState('')
   const [isHovered, setIsHovered] = useState(false)
@@ -65,10 +65,10 @@ const PointGroup = props => {
             <TextButton
               title="Ungroup and close"
               onClick={() => {
-                setPointObj({})
+                setPoint({})
                 onDone({
                   valid: true,
-                  value: { pointObj: undefined, removedPointObjs: groupedPoints },
+                  value: { point: undefined, removedPoints: groupedPoints },
                 })
               }}
             >
@@ -140,14 +140,11 @@ const PointGroup = props => {
                     },
                     [undefined, []]
                   )
-                  const newPointObj = {
-                    ...p,
-                    groupedPoints: g,
-                  }
-                  setPointObj(newPointObj)
+                  const newPoint = <Point {...p} groupedPoints={g} />
+                  setPoint(newPoint)
                   onDone({
                     valid: true,
-                    value: { pointObj: newPointObj },
+                    value: { point: newPoint },
                   })
                   setVState('edit')
                   setExpanded(false)
@@ -211,14 +208,17 @@ const PointGroup = props => {
                           title={`Select as Lead: ${point.subject}`}
                           children="Select as Lead"
                           onDone={() => {
-                            const newPointObj = {
-                              ...point,
-                              groupedPoints: [soloPoint, ...groupedPoints.filter((e, i) => i !== leadIndex)],
-                            }
-                            setPointObj(newPointObj)
+                            const newPoint = (
+                              <Point
+                                {...point}
+                                groupedPoints={[soloPoint, ...groupedPoints.filter((e, i) => i !== leadIndex)]}
+                              />
+                            )
+
+                            setPoint(newPoint)
                             onDone({
                               valid: true,
-                              value: { pointObj: newPointObj },
+                              value: { point: newPoint },
                             })
                           }}
                           disabled={false}
@@ -231,14 +231,14 @@ const PointGroup = props => {
                           title={`Remove from Group: ${point.subject}`}
                           children="Remove from Group"
                           onDone={() => {
-                            const newPointObj = {
-                              ...soloPoint,
-                              groupedPoints: groupedPoints.filter((e, i) => i !== leadIndex),
-                            }
-                            setPointObj(newPointObj)
+                            const newPoint = (
+                              <Point {...soloPoint} groupedPoints={groupedPoints.filter((e, i) => i !== leadIndex)} />
+                            )
+
+                            setPoint(newPoint)
                             onDone({
                               valid: true,
-                              value: { pointObj: newPointObj, removedPointObjs: [point] },
+                              value: { point: newPoint, removedPoints: [point] },
                             })
                           }}
                         />
@@ -306,14 +306,12 @@ const PointGroup = props => {
                   title="Ungroup"
                   children="Ungroup"
                   onDone={() => {
-                    const newPointObj = {
-                      ...soloPoint,
-                      groupedPoints: [],
-                    }
-                    setPointObj(newPointObj)
+                    const newPoint = <Point {...soloPoint} groupedPoints={[]} />
+
+                    setPoint(newPoint)
                     onDone({
                       valid: true,
-                      value: { pointObj: newPointObj, removedPointObjs: groupedPoints },
+                      value: { point: newPoint, removedPoints: groupedPoints },
                     })
                   }}
                 />

--- a/app/components/point-group.jsx
+++ b/app/components/point-group.jsx
@@ -156,7 +156,7 @@ const PointGroup = props => {
                   setPointDoc(newPointDoc)
                   onDone({
                     valid: true,
-                    value: { pointDoc: newPointDoc },
+                    value: { pointDoc: newPointDoc, groupedPoints: [] },
                   })
                   setVState('edit')
                   setExpanded(false)
@@ -227,7 +227,7 @@ const PointGroup = props => {
                             setPointDoc(newPointDoc)
                             onDone({
                               valid: true,
-                              value: { pointDoc: newPointDoc },
+                              value: { pointDoc: newPointDoc, groupedPoints: [] },
                             })
                           }}
                           disabled={false}

--- a/app/components/point-group.jsx
+++ b/app/components/point-group.jsx
@@ -88,8 +88,7 @@ const PointGroup = props => {
           </div>
           {expanded && (
             <div className={classes.selectPointsContainer}>
-              {groupedPoints?.map(point => {
-                const pointDoc = point.props.point
+              {groupedPoints?.map(pointDoc => {
                 const pointChildren = [
                   <div className={classes.invisibleElement}>
                     {/* this is here to take up space for the height calculation of every grid cell, but not be visible */}
@@ -212,8 +211,7 @@ const PointGroup = props => {
             <div className={classes.defaultWidth}>
               {!singlePoint && <p className={classes.titleGroup}>Edit the response you'd like to lead with</p>}
               <div className={classes.selectPointsContainer}>
-                {groupedPoints.map((point, leadIndex) => {
-                  const pointDoc = point.props.point
+                {groupedPoints.map((pointDoc, leadIndex) => {
                   const pointChildren = [
                     <div className={classes.pointBottomButtons}>
                       <div className={classes.pointWidthButton}>
@@ -273,8 +271,7 @@ const PointGroup = props => {
             <div className={classes.defaultWidth}>
               {!singlePoint && <p className={classes.titleGroup}>Other Responses</p>}
               <div className={classes.selectPointsContainer}>
-                {groupedPoints.map(point => {
-                  const pointDoc = point.props.point
+                {groupedPoints.map(pointDoc => {
                   return (
                     <div key={pointDoc._id} className={classes.selectPoints}>
                       <Point point={pointDoc} className={cx(classes.selectPointsPassDown, classes.noBoxShadow)} />

--- a/app/components/point.jsx
+++ b/app/components/point.jsx
@@ -1,5 +1,6 @@
 // https://github.com/EnCiv/civil-pursuit/issues/23
 // https://github.com/EnCiv/civil-pursuit/issues/76
+// https://github.com/EnCiv/civil-pursuit/issues/140
 
 'use strict'
 import React, { forwardRef, useState } from 'react'
@@ -7,9 +8,12 @@ import cx from 'classnames'
 import { createUseStyles } from 'react-jss'
 
 const Point = forwardRef((props, ref) => {
-  const { subject, description, vState, children, className, isLoading, ...otherProps } = props
+  const { point, vState = 'default', children = [], className = '', isLoading, ...otherProps } = props
   const classes = useStylesFromThemeFunction()
   const [isHovered, setIsHovered] = useState(false)
+
+  const subject = point ? point.subject : ''
+  const description = point ? point.description : ''
 
   const onMouseIn = () => {
     setIsHovered(true)

--- a/app/components/point.jsx
+++ b/app/components/point.jsx
@@ -6,14 +6,14 @@
 import React, { forwardRef, useState } from 'react'
 import cx from 'classnames'
 import { createUseStyles } from 'react-jss'
+import DemInfo from './dem-info.jsx'
 
 const Point = forwardRef((props, ref) => {
   const { point, vState = 'default', children = [], className = '', isLoading, ...otherProps } = props
   const classes = useStylesFromThemeFunction()
   const [isHovered, setIsHovered] = useState(false)
 
-  const subject = point ? point.subject : ''
-  const description = point ? point.description : ''
+  const { subject = '', description = '', demInfo = {} } = point || {}
 
   const onMouseIn = () => {
     setIsHovered(true)
@@ -62,6 +62,7 @@ const Point = forwardRef((props, ref) => {
               {isLoading ? '' : description}
             </div>
           )}
+          <DemInfo user={demInfo.user} />
           {childrenWithProps}
         </div>
       </div>

--- a/app/components/point.jsx
+++ b/app/components/point.jsx
@@ -62,7 +62,7 @@ const Point = forwardRef((props, ref) => {
               {isLoading ? '' : description}
             </div>
           )}
-          <DemInfo user={demInfo.user} />
+          <DemInfo {...demInfo} />
           {childrenWithProps}
         </div>
       </div>

--- a/app/components/rank-step.jsx
+++ b/app/components/rank-step.jsx
@@ -46,7 +46,7 @@ function RankStep(props) {
     <div className={cx(classes.rankStep, className)} {...otherProps}>
       <div className={classes.pointDiv}>
         {pointList.map((point, i) => (
-          <Point key={point._id} {...point} vState="default">
+          <Point key={point._id} point={point} vState="default">
             <Ranking
               className={classes.rank}
               defaultValue={(rankList.find(ro => ro.id === point._id) || {}).rank}

--- a/app/components/show-dual-point-list.jsx
+++ b/app/components/show-dual-point-list.jsx
@@ -4,6 +4,7 @@
 import React, { useState } from 'react'
 import { createUseStyles } from 'react-jss'
 import cx from 'classnames'
+import Point from './point'
 import PointGroup from './point-group'
 import { ModifierButton } from './button'
 
@@ -37,12 +38,12 @@ export default function ShowDualPointList({
             return (
               <React.Fragment key={leftPoint?._id || rightPoint?._id}>
                 <PointGroup
-                  pointObj={leftPoint || {}}
+                  point={<Point point={leftPoint || {}} />}
                   vState={isExpanded ? 'default' : 'collapsed'}
                   className={cx(classes.point, index % 2 === 0 ? classes.evenRow : classes.oddRow)}
                 />
                 <PointGroup
-                  pointObj={rightPoint || {}}
+                  point={<Point point={rightPoint || {}} />}
                   vState={isExpanded ? 'default' : 'collapsed'}
                   className={cx(classes.point, index % 2 === 0 ? classes.evenRow : classes.oddRow)}
                 />

--- a/app/components/show-dual-point-list.jsx
+++ b/app/components/show-dual-point-list.jsx
@@ -4,7 +4,6 @@
 import React, { useState } from 'react'
 import { createUseStyles } from 'react-jss'
 import cx from 'classnames'
-import Point from './point'
 import PointGroup from './point-group'
 import { ModifierButton } from './button'
 
@@ -38,12 +37,12 @@ export default function ShowDualPointList({
             return (
               <React.Fragment key={leftPoint?._id || rightPoint?._id}>
                 <PointGroup
-                  point={<Point point={leftPoint || {}} />}
+                  pointDoc={leftPoint || {}}
                   vState={isExpanded ? 'default' : 'collapsed'}
                   className={cx(classes.point, index % 2 === 0 ? classes.evenRow : classes.oddRow)}
                 />
                 <PointGroup
-                  point={<Point point={rightPoint || {}} />}
+                  pointDoc={rightPoint || {}}
                   vState={isExpanded ? 'default' : 'collapsed'}
                   className={cx(classes.point, index % 2 === 0 ? classes.evenRow : classes.oddRow)}
                 />

--- a/app/components/why-input.jsx
+++ b/app/components/why-input.jsx
@@ -1,59 +1,60 @@
 // https://github.com/EnCiv/civil-pursuit/issues/68
 
 'use strict'
-import React from 'react';
-import Point from './point';
-import PointInput from './point-input';
-import cx from 'classnames';
-import { createUseStyles } from 'react-jss';
-
+import React from 'react'
+import Point from './point'
+import PointInput from './point-input'
+import cx from 'classnames'
+import { createUseStyles } from 'react-jss'
 
 function WhyInput(props) {
-    const { point = { subject: "", description: "", _id: "" }, defaultValue = { subject: "", description: "" }, onDone = () => { }, className, ...otherProps } = props;
-    const classes = useStyles();
+  const {
+    point = { subject: '', description: '', _id: '' },
+    defaultValue = { subject: '', description: '' },
+    onDone = () => {},
+    className,
+    ...otherProps
+  } = props
+  const classes = useStyles()
 
-    const handleOnDone = ({ valid, value }) => {
-        value.parentId = `${point._id}`;
-        onDone({ valid, value })
-    }
+  const handleOnDone = ({ valid, value }) => {
+    value.parentId = `${point._id}`
+    onDone({ valid, value })
+  }
 
-    return (
-        <div className={cx(classes.container, className)} {...otherProps}>
-            <Point className={classes.point} {...point} vState="secondary" />
-            <PointInput className={classes.pointInput} onDone={handleOnDone} defaultValue={defaultValue} />
-        </div>
-    )
-
-
+  return (
+    <div className={cx(classes.container, className)} {...otherProps}>
+      <Point className={classes.point} point={point} vState="secondary" />
+      <PointInput className={classes.pointInput} onDone={handleOnDone} defaultValue={defaultValue} />
+    </div>
+  )
 }
 
 const useStyles = createUseStyles(theme => ({
-
+  container: {
+    display: 'flex',
+    gap: '1rem',
+    alignItems: 'center',
+  },
+  [`@media (max-width: ${theme.condensedWidthBreakPoint})`]: {
     container: {
-        display: 'flex',
-        gap: '1rem',
-        alignItems: 'center',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
     },
-    [`@media (max-width: ${theme.condensedWidthBreakPoint})`]: {
-        container: {
-            flexDirection: 'column',
-            alignItems: 'flex-start',
-        },
-    },
+  },
+  point: {},
+  pointInput: {
+    padding: '0 1.875rem',
+    boxSizing: 'border-box',
+  },
+  [`@media (min-width: ${theme.condensedWidthBreakPoint})`]: {
     point: {
+      width: '35%',
     },
     pointInput: {
-        padding: '0 1.875rem',
-        boxSizing: 'border-box',
+      width: '60%',
     },
-    [`@media (min-width: ${theme.condensedWidthBreakPoint})`]: {
-        point: {
-            width: '35%',
-        },
-        pointInput: {
-            width: '60%',
-        },
-    },
-}));
+  },
+}))
 
-export default WhyInput;
+export default WhyInput

--- a/stories/dem-info.stories.jsx
+++ b/stories/dem-info.stories.jsx
@@ -1,94 +1,74 @@
-import DemInfo from '../app/components/dem-info';
-import React from 'react';
+import DemInfo from '../app/components/dem-info'
+import React from 'react'
 
 export default {
-    component: DemInfo,
-    args: {}
+  component: DemInfo,
+  args: {},
 }
 
-export const PrimaryAllFieldsIncluded = { args: {
-    user: {
-        dob: '1990-10-20T00:00:00.000Z',
-        state: 'NY',
-        party: 'Independent'
-      },
-}}
+export const PrimaryAllFieldsIncluded = {
+  args: {
+    dob: '1990-10-20T00:00:00.000Z',
+    state: 'NY',
+    party: 'Independent',
+  },
+}
 
-export const UserNotFound = { args: {}}
-
-export const NoUserFields = { args: { user: {}}}
+export const UserNotFound = { args: {} }
 
 export const AgeAndStateOnly = {
-    args: {
-        user: {
-            dob: '1990-10-20T00:00:00.000Z',
-            state: 'NY',
-        },
-    }
+  args: {
+    dob: '1990-10-20T00:00:00.000Z',
+    state: 'NY',
+  },
 }
 
 export const StateAndPartyOnly = {
-    args: {
-        user: {
-            state: 'NY',
-            party: 'Independent',
-        },
-    }
+  args: {
+    state: 'NY',
+    party: 'Independent',
+  },
 }
 
 export const AgeAndPartyOnly = {
-    args: {
-        user: {
-            dob: '1990-10-20T00:00:00.000Z',
-            party: 'Independent',
-        },
-    }
+  args: {
+    dob: '1990-10-20T00:00:00.000Z',
+    party: 'Independent',
+  },
 }
 
 export const PartyOnly = {
-    args: {
-        user: {
-            party: 'Independent',
-        },
-    }
+  args: {
+    party: 'Independent',
+  },
 }
 
 export const AgeOnly = {
-    args: {
-        user: {
-            dob: '1990-10-20T00:00:00.000Z',
-        },
-    }
+  args: {
+    dob: '1990-10-20T00:00:00.000Z',
+  },
 }
 
 export const StateOnly = {
-    args: {
-        user: {
-            state: 'NY',
-        },
-    }
+  args: {
+    state: 'NY',
+  },
 }
 
 export const PartyOnlyEmptyField = {
-    args: {
-        user: {
-            party: '',
-        },
-    }
+  args: {
+    party: '',
+  },
 }
 
 export const AgeOnlyEmptyField = {
-    args: {
-        user: {
-            dob: null,
-        },
-    }
+  args: {
+    dob: null,
+  },
 }
 
 export const StateOnlyEmptyField = {
-    args: {
-        user: {
-            state: '',
-        },
-    }
+  args: {
+    state: '',
+  },
 }

--- a/stories/grouping-step.stories.jsx
+++ b/stories/grouping-step.stories.jsx
@@ -14,7 +14,7 @@ export default {
   },
 }
 
-const createPointObj = (
+const createPointDoc = (
   _id,
   subject,
   description = 'Point Description',
@@ -35,7 +35,7 @@ const createPointObj = (
 }
 
 const pointItems = Array.from({ length: 10 }, (_, index) =>
-  createPointObj(index, 'Point ' + index, 'Point Description ' + index)
+  createPointDoc(index, 'Point ' + index, 'Point Description ' + index)
 )
 
 export const Empty = {

--- a/stories/point-group.stories.jsx
+++ b/stories/point-group.stories.jsx
@@ -21,11 +21,9 @@ const createPointObj = (
   description = 'Point Description',
   groupedPoints = [],
   demInfo = {
-    user: {
-      dob: '1990-10-20T00:00:00.000Z',
-      state: 'NY',
-      party: 'Independent',
-    },
+    dob: '1990-10-20T00:00:00.000Z',
+    state: 'NY',
+    party: 'Independent',
   }
 ) => {
   return {
@@ -44,19 +42,15 @@ const point2 = createPointObj(
   'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
   [],
   {
-    user: {
-      dob: '1980-10-20T00:00:00.000Z',
-      state: 'GA',
-      party: 'Independent',
-    },
+    dob: '1980-10-20T00:00:00.000Z',
+    state: 'GA',
+    party: 'Independent',
   }
 )
 const point3 = createPointObj('3', 'Point 3', 'Point 3 Description', [], {
-  user: {
-    dob: '1995-10-20T00:00:00.000Z',
-    state: 'CA',
-    party: 'Independent',
-  },
+  dob: '1995-10-20T00:00:00.000Z',
+  state: 'CA',
+  party: 'Independent',
 })
 const point4 = createPointObj('4', 'Point 4', 'Point 4 Description')
 const point6 = createPointObj('6', 'Point 6', 'Point 6 Description')

--- a/stories/point-group.stories.jsx
+++ b/stories/point-group.stories.jsx
@@ -17,7 +17,7 @@ export default {
   },
 }
 
-const createPoint = (
+const createPointDoc = (
   _id,
   subject,
   description = 'Point Description',
@@ -28,21 +28,19 @@ const createPoint = (
     party: 'Independent',
   }
 ) => {
-  return (
-    <Point
-      point={{
-        _id,
-        subject,
-        description,
-        groupedPoints,
-        demInfo,
-      }}
-    />
-  )
+  return {
+    _id,
+    subject,
+    description,
+    groupedPoints,
+    demInfo,
+  }
 }
 
-const point1 = createPoint('1', 'Point 1', 'Point 1 Description', [])
-const point2 = createPoint(
+const createPoint = pointDoc => <Point point={pointDoc} />
+
+const pointDoc1 = createPointDoc('1', 'Point 1', 'Point 1 Description', [])
+const pointDoc2 = createPointDoc(
   '2',
   'Point 2',
   'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
@@ -53,14 +51,21 @@ const point2 = createPoint(
     party: 'Independent',
   }
 )
-const point3 = createPoint('3', 'Point 3', 'Point 3 Description', [], {
+const pointDoc3 = createPointDoc('3', 'Point 3', 'Point 3 Description', [], {
   dob: '1995-10-20T00:00:00.000Z',
   state: 'CA',
   party: 'Independent',
 })
-const point4 = createPoint('4', 'Point 4', 'Point 4 Description')
-const point6 = createPoint('6', 'Point 6', 'Point 6 Description')
-const point5 = createPoint('5', 'Point 5', 'Point 5 Description', [point2, point3, point4, point6])
+const pointDoc4 = createPointDoc('4', 'Point 4', 'Point 4 Description')
+const pointDoc6 = createPointDoc('6', 'Point 6', 'Point 6 Description')
+const pointDoc5 = createPointDoc('5', 'Point 5', 'Point 5 Description', [pointDoc2, pointDoc3, pointDoc4, pointDoc6])
+
+const point1 = createPoint(pointDoc1)
+const point2 = createPoint(pointDoc2)
+const point3 = createPoint(pointDoc3)
+const point4 = createPoint(pointDoc4)
+const point5 = createPoint(pointDoc5)
+const point6 = createPoint(pointDoc6)
 
 export const DefaultSinglePoint = { args: { point: point1, vState: 'default' } }
 export const SelectedSinglePoint = { args: { point: point1, vState: 'default', select: true } }

--- a/stories/point-group.stories.jsx
+++ b/stories/point-group.stories.jsx
@@ -20,10 +20,12 @@ const createPointObj = (
   subject,
   description = 'Point Description',
   groupedPoints = [],
-  user = {
-    dob: '1990-10-20T00:00:00.000Z',
-    state: 'NY',
-    party: 'Independent',
+  demInfo = {
+    user: {
+      dob: '1990-10-20T00:00:00.000Z',
+      state: 'NY',
+      party: 'Independent',
+    },
   }
 ) => {
   return {
@@ -31,7 +33,7 @@ const createPointObj = (
     subject,
     description,
     groupedPoints,
-    user,
+    demInfo,
   }
 }
 
@@ -42,15 +44,19 @@ const point2 = createPointObj(
   'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
   [],
   {
-    dob: '1980-10-20T00:00:00.000Z',
-    state: 'GA',
-    party: 'Independent',
+    user: {
+      dob: '1980-10-20T00:00:00.000Z',
+      state: 'GA',
+      party: 'Independent',
+    },
   }
 )
 const point3 = createPointObj('3', 'Point 3', 'Point 3 Description', [], {
-  dob: '1995-10-20T00:00:00.000Z',
-  state: 'CA',
-  party: 'Independent',
+  user: {
+    dob: '1995-10-20T00:00:00.000Z',
+    state: 'CA',
+    party: 'Independent',
+  },
 })
 const point4 = createPointObj('4', 'Point 4', 'Point 4 Description')
 const point6 = createPointObj('6', 'Point 6', 'Point 6 Description')
@@ -124,37 +130,45 @@ export const selectLeadPoint3OnDone = {
                 subject: 'Point 2',
                 description:
                   'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
-                user: {
-                  dob: '1980-10-20T00:00:00.000Z',
-                  state: 'GA',
-                  party: 'Independent',
+                demInfo: {
+                  user: {
+                    dob: '1980-10-20T00:00:00.000Z',
+                    state: 'GA',
+                    party: 'Independent',
+                  },
                 },
               },
               {
                 _id: '4',
                 subject: 'Point 4',
                 description: 'Point 4 Description',
-                user: {
-                  dob: '1990-10-20T00:00:00.000Z',
-                  state: 'NY',
-                  party: 'Independent',
+                deminfo: {
+                  user: {
+                    dob: '1990-10-20T00:00:00.000Z',
+                    state: 'NY',
+                    party: 'Independent',
+                  },
                 },
               },
               {
                 _id: '6',
                 subject: 'Point 6',
                 description: 'Point 6 Description',
-                user: {
-                  dob: '1990-10-20T00:00:00.000Z',
-                  state: 'NY',
-                  party: 'Independent',
+                demInfo: {
+                  user: {
+                    dob: '1990-10-20T00:00:00.000Z',
+                    state: 'NY',
+                    party: 'Independent',
+                  },
                 },
               },
             ],
-            user: {
-              dob: '1995-10-20T00:00:00.000Z',
-              state: 'CA',
-              party: 'Independent',
+            demInfo: {
+              user: {
+                dob: '1995-10-20T00:00:00.000Z',
+                state: 'CA',
+                party: 'Independent',
+              },
             },
           },
         },
@@ -182,10 +196,12 @@ export const selectLeadUngroupOnDone = {
               description:
                 'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
               groupedPoints: [],
-              user: {
-                dob: '1980-10-20T00:00:00.000Z',
-                state: 'GA',
-                party: 'Independent',
+              demInfo: {
+                user: {
+                  dob: '1980-10-20T00:00:00.000Z',
+                  state: 'GA',
+                  party: 'Independent',
+                },
               },
             },
             {
@@ -193,10 +209,12 @@ export const selectLeadUngroupOnDone = {
               subject: 'Point 3',
               description: 'Point 3 Description',
               groupedPoints: [],
-              user: {
-                dob: '1995-10-20T00:00:00.000Z',
-                state: 'CA',
-                party: 'Independent',
+              demInfo: {
+                user: {
+                  dob: '1995-10-20T00:00:00.000Z',
+                  state: 'CA',
+                  party: 'Independent',
+                },
               },
             },
             {
@@ -204,10 +222,12 @@ export const selectLeadUngroupOnDone = {
               subject: 'Point 4',
               description: 'Point 4 Description',
               groupedPoints: [],
-              user: {
-                dob: '1990-10-20T00:00:00.000Z',
-                state: 'NY',
-                party: 'Independent',
+              demInfo: {
+                user: {
+                  dob: '1990-10-20T00:00:00.000Z',
+                  state: 'NY',
+                  party: 'Independent',
+                },
               },
             },
             {
@@ -215,10 +235,12 @@ export const selectLeadUngroupOnDone = {
               subject: 'Point 6',
               description: 'Point 6 Description',
               groupedPoints: [],
-              user: {
-                dob: '1990-10-20T00:00:00.000Z',
-                state: 'NY',
-                party: 'Independent',
+              demInfo: {
+                user: {
+                  dob: '1990-10-20T00:00:00.000Z',
+                  state: 'NY',
+                  party: 'Independent',
+                },
               },
             },
           ],
@@ -244,10 +266,12 @@ export const editMultiplePointsRemovePoint3OnDone = {
             _id: '5',
             subject: 'Point 5',
             description: 'Point 5 Description',
-            user: {
-              dob: '1990-10-20T00:00:00.000Z',
-              state: 'NY',
-              party: 'Independent',
+            demInfo: {
+              user: {
+                dob: '1990-10-20T00:00:00.000Z',
+                state: 'NY',
+                party: 'Independent',
+              },
             },
             groupedPoints: [
               {
@@ -256,10 +280,12 @@ export const editMultiplePointsRemovePoint3OnDone = {
                 description:
                   'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
                 groupedPoints: [],
-                user: {
-                  dob: '1980-10-20T00:00:00.000Z',
-                  state: 'GA',
-                  party: 'Independent',
+                demInfo: {
+                  user: {
+                    dob: '1980-10-20T00:00:00.000Z',
+                    state: 'GA',
+                    party: 'Independent',
+                  },
                 },
               },
               {
@@ -267,10 +293,12 @@ export const editMultiplePointsRemovePoint3OnDone = {
                 subject: 'Point 4',
                 description: 'Point 4 Description',
                 groupedPoints: [],
-                user: {
-                  dob: '1990-10-20T00:00:00.000Z',
-                  state: 'NY',
-                  party: 'Independent',
+                demInfo: {
+                  user: {
+                    dob: '1990-10-20T00:00:00.000Z',
+                    state: 'NY',
+                    party: 'Independent',
+                  },
                 },
               },
               {
@@ -278,10 +306,12 @@ export const editMultiplePointsRemovePoint3OnDone = {
                 subject: 'Point 6',
                 description: 'Point 6 Description',
                 groupedPoints: [],
-                user: {
-                  dob: '1990-10-20T00:00:00.000Z',
-                  state: 'NY',
-                  party: 'Independent',
+                demInfo: {
+                  user: {
+                    dob: '1990-10-20T00:00:00.000Z',
+                    state: 'NY',
+                    party: 'Independent',
+                  },
                 },
               },
             ],
@@ -292,10 +322,12 @@ export const editMultiplePointsRemovePoint3OnDone = {
               subject: 'Point 3',
               description: 'Point 3 Description',
               groupedPoints: [],
-              user: {
-                dob: '1995-10-20T00:00:00.000Z',
-                state: 'CA',
-                party: 'Independent',
+              demInfo: {
+                user: {
+                  dob: '1995-10-20T00:00:00.000Z',
+                  state: 'CA',
+                  party: 'Independent',
+                },
               },
             },
           ],

--- a/stories/point-group.stories.jsx
+++ b/stories/point-group.stories.jsx
@@ -56,17 +56,17 @@ const point4 = createPointObj('4', 'Point 4', 'Point 4 Description')
 const point6 = createPointObj('6', 'Point 6', 'Point 6 Description')
 const point5 = createPointObj('5', 'Point 5', 'Point 5 Description', [point2, point3, point4, point6])
 
-export const DefaultSinglePoint = { args: { pointObj: point1, vState: 'default' } }
-export const SelectedSinglePoint = { args: { pointObj: point1, vState: 'default', select: true } }
-export const EditSinglePoint = { args: { pointObj: point1, vState: 'edit' } }
+export const DefaultSinglePoint = { args: { point: point1, vState: 'default' } }
+export const SelectedSinglePoint = { args: { point: point1, vState: 'default', select: true } }
+export const EditSinglePoint = { args: { point: point1, vState: 'edit' } }
 
-export const defaultMultiplePoints = { args: { pointObj: point5, vState: 'default' } }
-export const selectedDefaultMultiplePoints = { args: { pointObj: point5, vState: 'default', select: true } }
-export const editMultiplePoints = { args: { pointObj: point5, vState: 'edit' } }
-export const selectedEditMultiplePoints = { args: { pointObj: point5, vState: 'edit', select: true } }
+export const defaultMultiplePoints = { args: { point: point5, vState: 'default' } }
+export const selectedDefaultMultiplePoints = { args: { point: point5, vState: 'default', select: true } }
+export const editMultiplePoints = { args: { point: point5, vState: 'edit' } }
+export const selectedEditMultiplePoints = { args: { point: point5, vState: 'edit', select: true } }
 
-export const mobileSingePoint = {
-  args: { pointObj: point1, vState: 'default' },
+export const mobileSinglePoint = {
+  args: { point: point1, vState: 'default' },
   parameters: {
     viewport: {
       defaultViewport: 'iphonex',
@@ -75,7 +75,7 @@ export const mobileSingePoint = {
 }
 
 export const mobileDefaultPoints = {
-  args: { pointObj: point5, vState: 'default' },
+  args: { point: point5, vState: 'default' },
   parameters: {
     viewport: {
       defaultViewport: 'iphonex',
@@ -84,15 +84,15 @@ export const mobileDefaultPoints = {
 }
 
 export const collapsedPoints = {
-  args: { pointObj: point5, vState: 'collapsed' },
+  args: { point: point5, vState: 'collapsed' },
 }
 
 export const selectLeadPoints = {
-  args: { pointObj: point5, vState: 'selectLead' },
+  args: { point: point5, vState: 'selectLead' },
 }
 
 export const mobileSelectLeadPoints = {
-  args: { pointObj: point5, vState: 'selectLead' },
+  args: { point: point5, vState: 'selectLead' },
   parameters: {
     viewport: {
       defaultViewport: 'iphonex',
@@ -101,7 +101,7 @@ export const mobileSelectLeadPoints = {
 }
 
 export const selectLeadPoint3OnDone = {
-  args: { pointObj: point5, vState: 'selectLead' },
+  args: { point: point5, vState: 'selectLead' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const SelectedPoint = canvas.getByTitle('Select as Lead: Point 3')
@@ -164,7 +164,7 @@ export const selectLeadPoint3OnDone = {
 }
 
 export const selectLeadUngroupOnDone = {
-  args: { pointObj: point5, vState: 'selectLead' },
+  args: { point: point5, vState: 'selectLead' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const element = canvas.getByTitle('Ungroup and close')

--- a/stories/point-group.stories.jsx
+++ b/stories/point-group.stories.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { expect } from '@storybook/jest'
-import Point from '../app/components/point'
 import PointGroup from '../app/components/point-group'
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 import { onDoneDecorator, onDoneResult } from './common'
@@ -37,8 +36,6 @@ const createPointDoc = (
   }
 }
 
-const createPoint = pointDoc => <Point point={pointDoc} />
-
 const pointDoc1 = createPointDoc('1', 'Point 1', 'Point 1 Description', [])
 const pointDoc2 = createPointDoc(
   '2',
@@ -60,24 +57,17 @@ const pointDoc4 = createPointDoc('4', 'Point 4', 'Point 4 Description')
 const pointDoc6 = createPointDoc('6', 'Point 6', 'Point 6 Description')
 const pointDoc5 = createPointDoc('5', 'Point 5', 'Point 5 Description', [pointDoc2, pointDoc3, pointDoc4, pointDoc6])
 
-const point1 = createPoint(pointDoc1)
-const point2 = createPoint(pointDoc2)
-const point3 = createPoint(pointDoc3)
-const point4 = createPoint(pointDoc4)
-const point5 = createPoint(pointDoc5)
-const point6 = createPoint(pointDoc6)
+export const DefaultSinglePoint = { args: { pointDoc: pointDoc1, vState: 'default' } }
+export const SelectedSinglePoint = { args: { pointDoc: pointDoc1, vState: 'default', select: true } }
+export const EditSinglePoint = { args: { pointDoc: pointDoc1, vState: 'edit' } }
 
-export const DefaultSinglePoint = { args: { point: point1, vState: 'default' } }
-export const SelectedSinglePoint = { args: { point: point1, vState: 'default', select: true } }
-export const EditSinglePoint = { args: { point: point1, vState: 'edit' } }
-
-export const defaultMultiplePoints = { args: { point: point5, vState: 'default' } }
-export const selectedDefaultMultiplePoints = { args: { point: point5, vState: 'default', select: true } }
-export const editMultiplePoints = { args: { point: point5, vState: 'edit' } }
-export const selectedEditMultiplePoints = { args: { point: point5, vState: 'edit', select: true } }
+export const defaultMultiplePoints = { args: { pointDoc: pointDoc5, vState: 'default' } }
+export const selectedDefaultMultiplePoints = { args: { pointDoc: pointDoc5, vState: 'default', select: true } }
+export const editMultiplePoints = { args: { pointDoc: pointDoc5, vState: 'edit' } }
+export const selectedEditMultiplePoints = { args: { pointDoc: pointDoc5, vState: 'edit', select: true } }
 
 export const mobileSinglePoint = {
-  args: { point: point1, vState: 'default' },
+  args: { pointDoc: pointDoc1, vState: 'default' },
   parameters: {
     viewport: {
       defaultViewport: 'iphonex',
@@ -87,23 +77,15 @@ export const mobileSinglePoint = {
 
 export const selectedEditMultiplePointsWithChildren = {
   args: {
-    point: point5,
+    pointDoc: pointDoc5,
     vState: 'edit',
     select: true,
-    children: [
-      <DemInfo
-        user={{
-          dob: '1995-10-20T00:00:00.000Z',
-          state: 'CA',
-          party: 'Independent',
-        }}
-      />,
-    ],
+    children: [<DemInfo dob="1995-10-20T00:00:00.000Z" state="CA" party="Independent" />],
   },
 }
 
 export const mobileDefaultPoints = {
-  args: { point: point5, vState: 'default' },
+  args: { pointDoc: pointDoc5, vState: 'default' },
   parameters: {
     viewport: {
       defaultViewport: 'iphonex',
@@ -112,15 +94,15 @@ export const mobileDefaultPoints = {
 }
 
 export const collapsedPoints = {
-  args: { point: point5, vState: 'collapsed' },
+  args: { pointDoc: pointDoc5, vState: 'collapsed' },
 }
 
 export const selectLeadPoints = {
-  args: { point: point5, vState: 'selectLead' },
+  args: { pointDoc: pointDoc5, vState: 'selectLead' },
 }
 
 export const mobileSelectLeadPoints = {
-  args: { point: point5, vState: 'selectLead' },
+  args: { pointDoc: pointDoc5, vState: 'selectLead' },
   parameters: {
     viewport: {
       defaultViewport: 'iphonex',
@@ -129,7 +111,7 @@ export const mobileSelectLeadPoints = {
 }
 
 export const selectLeadPoint3OnDone = {
-  args: { point: point5, vState: 'selectLead' },
+  args: { pointDoc: pointDoc5, vState: 'selectLead' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const SelectedPoint = canvas.getByTitle('Select as Lead: Point 3')
@@ -192,7 +174,7 @@ export const selectLeadPoint3OnDone = {
 }
 
 export const selectLeadUngroupOnDone = {
-  args: { point: point5, vState: 'selectLead' },
+  args: { pointDoc: pointDoc5, vState: 'selectLead' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const element = canvas.getByTitle('Ungroup and close')
@@ -257,7 +239,7 @@ export const selectLeadUngroupOnDone = {
 }
 
 export const editMultiplePointsRemovePoint3OnDone = {
-  args: { point: point5, vState: 'edit' },
+  args: { pointDoc: pointDoc5, vState: 'edit' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const element = canvas.getByTitle('Remove from Group: Point 3')

--- a/stories/point-group.stories.jsx
+++ b/stories/point-group.stories.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { expect } from '@storybook/jest'
+import Point from '../app/components/point'
 import PointGroup from '../app/components/point-group'
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 import { onDoneDecorator, onDoneResult } from './common'
@@ -16,7 +17,7 @@ export default {
   },
 }
 
-const createPointObj = (
+const createPoint = (
   _id,
   subject,
   description = 'Point Description',
@@ -27,17 +28,21 @@ const createPointObj = (
     party: 'Independent',
   }
 ) => {
-  return {
-    _id,
-    subject,
-    description,
-    groupedPoints,
-    demInfo,
-  }
+  return (
+    <Point
+      point={{
+        _id,
+        subject,
+        description,
+        groupedPoints,
+        demInfo,
+      }}
+    />
+  )
 }
 
-const point1 = createPointObj('1', 'Point 1', 'Point 1 Description', [])
-const point2 = createPointObj(
+const point1 = createPoint('1', 'Point 1', 'Point 1 Description', [])
+const point2 = createPoint(
   '2',
   'Point 2',
   'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
@@ -48,14 +53,14 @@ const point2 = createPointObj(
     party: 'Independent',
   }
 )
-const point3 = createPointObj('3', 'Point 3', 'Point 3 Description', [], {
+const point3 = createPoint('3', 'Point 3', 'Point 3 Description', [], {
   dob: '1995-10-20T00:00:00.000Z',
   state: 'CA',
   party: 'Independent',
 })
-const point4 = createPointObj('4', 'Point 4', 'Point 4 Description')
-const point6 = createPointObj('6', 'Point 6', 'Point 6 Description')
-const point5 = createPointObj('5', 'Point 5', 'Point 5 Description', [point2, point3, point4, point6])
+const point4 = createPoint('4', 'Point 4', 'Point 4 Description')
+const point6 = createPoint('6', 'Point 6', 'Point 6 Description')
+const point5 = createPoint('5', 'Point 5', 'Point 5 Description', [point2, point3, point4, point6])
 
 export const DefaultSinglePoint = { args: { point: point1, vState: 'default' } }
 export const SelectedSinglePoint = { args: { point: point1, vState: 'default', select: true } }
@@ -132,7 +137,7 @@ export const selectLeadPoint3OnDone = {
       onDoneResult: {
         valid: true,
         value: {
-          pointObj: {
+          pointDoc: {
             _id: '3',
             subject: 'Point 3',
             description: 'Point 3 Description',
@@ -152,7 +157,7 @@ export const selectLeadPoint3OnDone = {
                 _id: '4',
                 subject: 'Point 4',
                 description: 'Point 4 Description',
-                deminfo: {
+                demInfo: {
                   dob: '1990-10-20T00:00:00.000Z',
                   state: 'NY',
                   party: 'Independent',
@@ -193,7 +198,7 @@ export const selectLeadUngroupOnDone = {
       onDoneResult: {
         valid: true,
         value: {
-          removedPointObjs: [
+          removedPointDocs: [
             {
               _id: '2',
               subject: 'Point 2',
@@ -247,7 +252,7 @@ export const selectLeadUngroupOnDone = {
 }
 
 export const editMultiplePointsRemovePoint3OnDone = {
-  args: { pointObj: point5, vState: 'edit' },
+  args: { point: point5, vState: 'edit' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const element = canvas.getByTitle('Remove from Group: Point 3')
@@ -258,7 +263,7 @@ export const editMultiplePointsRemovePoint3OnDone = {
       onDoneResult: {
         valid: true,
         value: {
-          pointObj: {
+          pointDoc: {
             _id: '5',
             subject: 'Point 5',
             description: 'Point 5 Description',
@@ -304,7 +309,7 @@ export const editMultiplePointsRemovePoint3OnDone = {
               },
             ],
           },
-          removedPointObjs: [
+          removedPointDocs: [
             {
               _id: '3',
               subject: 'Point 3',

--- a/stories/point-group.stories.jsx
+++ b/stories/point-group.stories.jsx
@@ -4,6 +4,7 @@ import PointGroup from '../app/components/point-group'
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 import { onDoneDecorator, onDoneResult } from './common'
 import { within, userEvent } from '@storybook/testing-library'
+import DemInfo from '../app/components/dem-info'
 
 export default {
   component: PointGroup,
@@ -71,6 +72,23 @@ export const mobileSinglePoint = {
     viewport: {
       defaultViewport: 'iphonex',
     },
+  },
+}
+
+export const selectedEditMultiplePointsWithChildren = {
+  args: {
+    point: point5,
+    vState: 'edit',
+    select: true,
+    children: [
+      <DemInfo
+        user={{
+          dob: '1995-10-20T00:00:00.000Z',
+          state: 'CA',
+          party: 'Independent',
+        }}
+      />,
+    ],
   },
 }
 

--- a/stories/point-group.stories.jsx
+++ b/stories/point-group.stories.jsx
@@ -131,11 +131,9 @@ export const selectLeadPoint3OnDone = {
                 description:
                   'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
                 demInfo: {
-                  user: {
-                    dob: '1980-10-20T00:00:00.000Z',
-                    state: 'GA',
-                    party: 'Independent',
-                  },
+                  dob: '1980-10-20T00:00:00.000Z',
+                  state: 'GA',
+                  party: 'Independent',
                 },
               },
               {
@@ -143,11 +141,9 @@ export const selectLeadPoint3OnDone = {
                 subject: 'Point 4',
                 description: 'Point 4 Description',
                 deminfo: {
-                  user: {
-                    dob: '1990-10-20T00:00:00.000Z',
-                    state: 'NY',
-                    party: 'Independent',
-                  },
+                  dob: '1990-10-20T00:00:00.000Z',
+                  state: 'NY',
+                  party: 'Independent',
                 },
               },
               {
@@ -155,20 +151,16 @@ export const selectLeadPoint3OnDone = {
                 subject: 'Point 6',
                 description: 'Point 6 Description',
                 demInfo: {
-                  user: {
-                    dob: '1990-10-20T00:00:00.000Z',
-                    state: 'NY',
-                    party: 'Independent',
-                  },
+                  dob: '1990-10-20T00:00:00.000Z',
+                  state: 'NY',
+                  party: 'Independent',
                 },
               },
             ],
             demInfo: {
-              user: {
-                dob: '1995-10-20T00:00:00.000Z',
-                state: 'CA',
-                party: 'Independent',
-              },
+              dob: '1995-10-20T00:00:00.000Z',
+              state: 'CA',
+              party: 'Independent',
             },
           },
         },
@@ -197,11 +189,9 @@ export const selectLeadUngroupOnDone = {
                 'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
               groupedPoints: [],
               demInfo: {
-                user: {
-                  dob: '1980-10-20T00:00:00.000Z',
-                  state: 'GA',
-                  party: 'Independent',
-                },
+                dob: '1980-10-20T00:00:00.000Z',
+                state: 'GA',
+                party: 'Independent',
               },
             },
             {
@@ -210,11 +200,9 @@ export const selectLeadUngroupOnDone = {
               description: 'Point 3 Description',
               groupedPoints: [],
               demInfo: {
-                user: {
-                  dob: '1995-10-20T00:00:00.000Z',
-                  state: 'CA',
-                  party: 'Independent',
-                },
+                dob: '1995-10-20T00:00:00.000Z',
+                state: 'CA',
+                party: 'Independent',
               },
             },
             {
@@ -223,11 +211,9 @@ export const selectLeadUngroupOnDone = {
               description: 'Point 4 Description',
               groupedPoints: [],
               demInfo: {
-                user: {
-                  dob: '1990-10-20T00:00:00.000Z',
-                  state: 'NY',
-                  party: 'Independent',
-                },
+                dob: '1990-10-20T00:00:00.000Z',
+                state: 'NY',
+                party: 'Independent',
               },
             },
             {
@@ -236,11 +222,9 @@ export const selectLeadUngroupOnDone = {
               description: 'Point 6 Description',
               groupedPoints: [],
               demInfo: {
-                user: {
-                  dob: '1990-10-20T00:00:00.000Z',
-                  state: 'NY',
-                  party: 'Independent',
-                },
+                dob: '1990-10-20T00:00:00.000Z',
+                state: 'NY',
+                party: 'Independent',
               },
             },
           ],
@@ -267,11 +251,9 @@ export const editMultiplePointsRemovePoint3OnDone = {
             subject: 'Point 5',
             description: 'Point 5 Description',
             demInfo: {
-              user: {
-                dob: '1990-10-20T00:00:00.000Z',
-                state: 'NY',
-                party: 'Independent',
-              },
+              dob: '1990-10-20T00:00:00.000Z',
+              state: 'NY',
+              party: 'Independent',
             },
             groupedPoints: [
               {
@@ -281,11 +263,9 @@ export const editMultiplePointsRemovePoint3OnDone = {
                   'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
                 groupedPoints: [],
                 demInfo: {
-                  user: {
-                    dob: '1980-10-20T00:00:00.000Z',
-                    state: 'GA',
-                    party: 'Independent',
-                  },
+                  dob: '1980-10-20T00:00:00.000Z',
+                  state: 'GA',
+                  party: 'Independent',
                 },
               },
               {
@@ -294,11 +274,9 @@ export const editMultiplePointsRemovePoint3OnDone = {
                 description: 'Point 4 Description',
                 groupedPoints: [],
                 demInfo: {
-                  user: {
-                    dob: '1990-10-20T00:00:00.000Z',
-                    state: 'NY',
-                    party: 'Independent',
-                  },
+                  dob: '1990-10-20T00:00:00.000Z',
+                  state: 'NY',
+                  party: 'Independent',
                 },
               },
               {
@@ -307,11 +285,9 @@ export const editMultiplePointsRemovePoint3OnDone = {
                 description: 'Point 6 Description',
                 groupedPoints: [],
                 demInfo: {
-                  user: {
-                    dob: '1990-10-20T00:00:00.000Z',
-                    state: 'NY',
-                    party: 'Independent',
-                  },
+                  dob: '1990-10-20T00:00:00.000Z',
+                  state: 'NY',
+                  party: 'Independent',
                 },
               },
             ],
@@ -323,11 +299,9 @@ export const editMultiplePointsRemovePoint3OnDone = {
               description: 'Point 3 Description',
               groupedPoints: [],
               demInfo: {
-                user: {
-                  dob: '1995-10-20T00:00:00.000Z',
-                  state: 'CA',
-                  party: 'Independent',
-                },
+                dob: '1995-10-20T00:00:00.000Z',
+                state: 'CA',
+                party: 'Independent',
               },
             },
           ],

--- a/stories/point.stories.jsx
+++ b/stories/point.stories.jsx
@@ -24,9 +24,12 @@ const DemInfoTestComponent = props => {
 export default {
   component: Point,
   args: {
-    subject: 'Phasellus diam sapien, placerat id sollicitudin eget',
-    description:
-      'Cras porttitor quam eros, vel auctor magna consequat vitae. Donec condimentum ac libero mollis tristique.',
+    point: {
+      subject: 'Phasellus diam sapien, placerat id sollicitudin eget',
+      description:
+        'Cras porttitor quam eros, vel auctor magna consequat vitae. Donec condimentum ac libero mollis tristique.',
+      demInfo: { dob: '1990-10-20T00:00:00.000Z', state: 'NY', party: 'Independent' },
+    },
   },
 }
 
@@ -34,8 +37,12 @@ export default {
 export const Empty = () => {
   return <Point />
 }
-export const PrimaryDefault = { args: { vState: 'default', children: <DemInfoTestComponent /> } }
-export const PrimarySelected = { args: { vState: 'selected', children: <DemInfoTestComponent /> } }
+export const PrimaryDefault = {
+  args: { vState: 'default' },
+}
+export const PrimarySelected = {
+  args: { vState: 'selected' },
+}
 export const PrimaryDisabled = { args: { vState: 'disabled' } }
 
 export const Lead = {
@@ -56,8 +63,11 @@ export const MultipleChildren = {
     vState: 'default',
     children: (
       <>
-        <DemInfoTestComponent />
         <PointLeadButton vState="default" />
+        <Point
+          point={{ _id: '42', subject: 'sub child', description: 'this is a point as a child of a point' }}
+          style={{ width: '100%' }}
+        />
       </>
     ),
   },
@@ -68,8 +78,9 @@ export const MultipleChildrenSelected = {
     vState: 'selected',
     children: (
       <>
-        <DemInfoTestComponent />
-        <PointLeadButton vState="selected" />
+        <PointLeadButton />
+        <PointLeadButton />
+        <PointLeadButton />
       </>
     ),
   },
@@ -79,11 +90,10 @@ export const ParentsWidth = args => {
   return (
     <div style={{ width: '33.5625rem' }}>
       <Point
-        point={args}
+        {...args}
         vState={'default'}
         children={
           <>
-            <DemInfoTestComponent />
             <PointLeadButton vState="default" />
           </>
         }
@@ -92,12 +102,12 @@ export const ParentsWidth = args => {
   )
 }
 
-export const Collapsed = args => {
-  return <Point vState={'collapsed'} point={args} />
+export const Collapsed = {
+  args: { vState: 'collapsed' },
 }
 
 export const Secondary = args => {
-  return <Point vState={'secondary'} point={args} children={<DemInfoTestComponent />} />
+  return <Point {...args} vState={'secondary'} />
 }
 
 export const LoadingLoop = () => {

--- a/stories/point.stories.jsx
+++ b/stories/point.stories.jsx
@@ -79,7 +79,7 @@ export const ParentsWidth = args => {
   return (
     <div style={{ width: '33.5625rem' }}>
       <Point
-        {...args}
+        point={args}
         vState={'default'}
         children={
           <>
@@ -93,11 +93,11 @@ export const ParentsWidth = args => {
 }
 
 export const Collapsed = args => {
-  return <Point vState={'collapsed'} subject={args.subject} />
+  return <Point vState={'collapsed'} point={args} />
 }
 
 export const Secondary = args => {
-  return <Point vState={'secondary'} subject={args.subject} children={<DemInfoTestComponent />} />
+  return <Point vState={'secondary'} point={args} children={<DemInfoTestComponent />} />
 }
 
 export const LoadingLoop = () => {

--- a/stories/why-input.stories.jsx
+++ b/stories/why-input.stories.jsx
@@ -26,7 +26,7 @@ const point = {
   subject: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at bibendum sapien',
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at bibendum sapien',
   _id: 'ExampleId',
-  demInfo: { user: user },
+  demInfo: { user },
 }
 
 export const ExamplePoint = {

--- a/stories/why-input.stories.jsx
+++ b/stories/why-input.stories.jsx
@@ -16,17 +16,15 @@ export default {
   },
 }
 
-const user = {
-  dob: '1990-10-20T00:00:00.000Z',
-  state: 'NY',
-  party: 'Independent',
-}
-
 const point = {
   subject: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at bibendum sapien',
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at bibendum sapien',
   _id: 'ExampleId',
-  demInfo: { user },
+  demInfo: {
+    dob: '1990-10-20T00:00:00.000Z',
+    state: 'NY',
+    party: 'Independent',
+  },
 }
 
 export const ExamplePoint = {

--- a/stories/why-input.stories.jsx
+++ b/stories/why-input.stories.jsx
@@ -1,88 +1,87 @@
-import { userEvent, within } from "@storybook/testing-library";
-import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
-import React from 'react';
-import WhyInput from "../app/components/why-input";
-import expect from 'expect';
-import { onDoneDecorator, onDoneResult } from "./common";
-import DemInfo from '../app/components/dem-info';
+import { userEvent, within } from '@storybook/testing-library'
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+import React from 'react'
+import WhyInput from '../app/components/why-input'
+import expect from 'expect'
+import { onDoneDecorator, onDoneResult } from './common'
 
 export default {
-    component: WhyInput,
-    args: {},
-    decorators: [onDoneDecorator],
-    parameters: {
-        viewport: {
-            viewports: INITIAL_VIEWPORTS
-        }
-    }
+  component: WhyInput,
+  args: {},
+  decorators: [onDoneDecorator],
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+    },
+  },
 }
 
 const user = {
-    dob: '1990-10-20T00:00:00.000Z',
-    state: 'NY',
-    party: 'Independent'
+  dob: '1990-10-20T00:00:00.000Z',
+  state: 'NY',
+  party: 'Independent',
 }
 
 const point = {
-    subject: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at bibendum sapien",
-    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at bibendum sapien",
-    _id: "ExampleId",
-    children: <DemInfo user={user} />
+  subject: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at bibendum sapien',
+  description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at bibendum sapien',
+  _id: 'ExampleId',
+  demInfo: { user: user },
 }
 
 export const ExamplePoint = {
-    args: {
-        point
-    },
+  args: {
+    point,
+  },
 }
 
 export const Empty = {
-    args: {}
+  args: {},
 }
 
 export const Mobile = {
-    parameters: {
-        viewport: {
-            defaultViewport: 'iphonex',
-        }
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphonex',
     },
-    args: {
-        point
-    },
+  },
+  args: {
+    point,
+  },
 }
 
 export const onDoneTest = {
-    args: {
-        point: {
-            subject: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at bibendum sapien",
-            description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at bibendum sapien",
-            _id: "ExampleId",
-        }
+  args: {
+    point: {
+      subject: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at bibendum sapien',
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at bibendum sapien',
+      _id: 'ExampleId',
     },
-    play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement)
-        const subjectEle = canvas.getByPlaceholderText(/type some thing here/i)
-        const descriptionEle = canvas.getByPlaceholderText(/description/i)
-        await userEvent.type(subjectEle, 'This is the subject!')
-        await userEvent.tab() // onDone will be called after moving out of input field
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const subjectEle = canvas.getByPlaceholderText(/type some thing here/i)
+    const descriptionEle = canvas.getByPlaceholderText(/description/i)
+    await userEvent.type(subjectEle, 'This is the subject!')
+    await userEvent.tab() // onDone will be called after moving out of input field
 
-        expect(onDoneResult(canvas)).toMatchObject({
-            count: 1,
-            onDoneResult: { valid: false, value: { subject: 'This is the subject!', description: '' } }
-        })
+    expect(onDoneResult(canvas)).toMatchObject({
+      count: 1,
+      onDoneResult: { valid: false, value: { subject: 'This is the subject!', description: '' } },
+    })
 
-        await userEvent.type(descriptionEle, 'This is the description!')
-        await userEvent.tab() // onDone will be called after moving out of input field
+    await userEvent.type(descriptionEle, 'This is the description!')
+    await userEvent.tab() // onDone will be called after moving out of input field
 
-        expect(onDoneResult(canvas)).toMatchObject({
-            count: 2,
-            onDoneResult: {
-                valid: true,
-                value: {
-                    subject: 'This is the subject!',
-                    description: 'This is the description!',
-                }
-            }
-        })
-    }
+    expect(onDoneResult(canvas)).toMatchObject({
+      count: 2,
+      onDoneResult: {
+        valid: true,
+        value: {
+          subject: 'This is the subject!',
+          description: 'This is the description!',
+        },
+      },
+    })
+  },
 }

--- a/stories/why-step.stories.jsx
+++ b/stories/why-step.stories.jsx
@@ -1,244 +1,250 @@
-import React from 'react';
-import { userEvent, within } from "@storybook/testing-library";
-import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
-import WhyStep from '../app/components/why-step';
-import expect from 'expect';
-import { onDoneDecorator, onDoneResult } from "./common";
-import DemInfo from '../app/components/dem-info';
+import React from 'react'
+import { userEvent, within } from '@storybook/testing-library'
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+import WhyStep from '../app/components/why-step'
+import expect from 'expect'
+import { onDoneDecorator, onDoneResult } from './common'
 
 export default {
-    component: WhyStep,
-    args: {},
-    decorators: [onDoneDecorator],
-    parameters: {
-        viewport: {
-            viewports: INITIAL_VIEWPORTS
-        },
+  component: WhyStep,
+  args: {},
+  decorators: [onDoneDecorator],
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
     },
-};
+  },
+}
 
 const createPointObj = (
+  _id,
+  subject,
+  description = 'Point Description',
+  groupedPoints = [],
+  demInfo = {
+    dob: '1990-10-20T00:00:00.000Z',
+    state: 'NY',
+    party: 'Independent',
+  }
+) => {
+  return {
     _id,
     subject,
-    description = 'Point Description',
-    groupedPoints = [],
-    user = {
-        dob: '1990-10-20T00:00:00.000Z',
-        state: 'NY',
-        party: 'Independent',
-    }
-) => {
-    return {
-        _id,
-        subject,
-        description,
-        children: <DemInfo user={user} />,
-    };
-};
+    description,
+    demInfo,
+  }
+}
 
-const point1 = createPointObj('1', 'Point 1', 'Point 1 Description', []);
+const point1 = createPointObj('1', 'Point 1', 'Point 1 Description', [])
 const point2 = createPointObj(
-    '2',
-    'Point 2',
-    'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
-    [],
-    {
-        dob: '1980-10-20T00:00:00.000Z',
-        state: 'GA',
-        party: 'Independent',
-    }
-);
+  '2',
+  'Point 2',
+  'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
+  [],
+  {
+    dob: '1980-10-20T00:00:00.000Z',
+    state: 'GA',
+    party: 'Independent',
+  }
+)
 const point3 = createPointObj('3', 'Point 3', 'Point 3 Description', [], {
-    dob: '1995-10-20T00:00:00.000Z',
-    state: 'CA',
-    party: 'Independent',
-});
+  dob: '1995-10-20T00:00:00.000Z',
+  state: 'CA',
+  party: 'Independent',
+})
 const point4 = createPointObj('4', 'Point 4', 'Point 4 Description', [], {
-    dob: '1998-10-20T00:00:00.000Z',
-    state: 'CO',
-    party: 'Independent',
-});
+  dob: '1998-10-20T00:00:00.000Z',
+  state: 'CO',
+  party: 'Independent',
+})
 
 const defaultSharedPoints = {
-    mosts: [point1, point2],
-    leasts: [point3, point4],
-    whyMosts: [point1, point2],
-    whyLeasts: [point3, point4],
-};
+  mosts: [point1, point2],
+  leasts: [point3, point4],
+  whyMosts: [point1, point2],
+  whyLeasts: [point3, point4],
+}
 
 export const mostPoints = {
-    args: {
-        type: "most",
-        intro: "Of the issues you thought were Most important, please give a brief explanation of why it's important for everyone to consider it",
-        shared: defaultSharedPoints
-    },
-};
+  args: {
+    type: 'most',
+    intro:
+      "Of the issues you thought were Most important, please give a brief explanation of why it's important for everyone to consider it",
+    shared: defaultSharedPoints,
+  },
+}
 
 export const leastPoints = {
-    args: {
-        type: "least",
-        intro: "Of the issues you thought were Least important, please give a brief explanation of why it's important for everyone to consider it",
-        shared: defaultSharedPoints
-    },
-};
+  args: {
+    type: 'least',
+    intro:
+      "Of the issues you thought were Least important, please give a brief explanation of why it's important for everyone to consider it",
+    shared: defaultSharedPoints,
+  },
+}
 
 export const mobileMostPoints = {
-    args: {
-        type: "most",
-        intro: "Of the issues you thought were Most important, please give a brief explanation of why it's important for everyone to consider it",
-        shared: defaultSharedPoints
+  args: {
+    type: 'most',
+    intro:
+      "Of the issues you thought were Most important, please give a brief explanation of why it's important for everyone to consider it",
+    shared: defaultSharedPoints,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphonex',
     },
-    parameters: {
-        viewport: {
-            defaultViewport: 'iphonex',
-        }
-    },
-};
+  },
+}
 
 export const mobileLeastPoints = {
-    args: {
-        type: "least",
-        intro: "Of the issues you thought were Least important, please give a brief explanation of why it's important for everyone to consider it",
-        shared: defaultSharedPoints
+  args: {
+    type: 'least',
+    intro:
+      "Of the issues you thought were Least important, please give a brief explanation of why it's important for everyone to consider it",
+    shared: defaultSharedPoints,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphonex',
     },
-    parameters: {
-        viewport: {
-            defaultViewport: 'iphonex',
-        }
-    },
-};
+  },
+}
 
 export const zeroPoints = {
-    args: {
-        type: "most",
-        intro: "Of the issues you thought were Most important, please give a brief explanation of why it's important for everyone to consider it",
-        shared: { mosts: [], leasts: [], whyMosts: [], whyLeasts: [] },
-    },
+  args: {
+    type: 'most',
+    intro:
+      "Of the issues you thought were Most important, please give a brief explanation of why it's important for everyone to consider it",
+    shared: { mosts: [], leasts: [], whyMosts: [], whyLeasts: [] },
+  },
 
-    play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
 
-        expect(onDoneResult(canvas)).toMatchObject({
-            count: 1,
-            onDoneResult: {
-                valid: true,
-                value: []
-            }
-        });
-    }
-};
+    expect(onDoneResult(canvas)).toMatchObject({
+      count: 1,
+      onDoneResult: {
+        valid: true,
+        value: [],
+      },
+    })
+  },
+}
 
 export const empty = {
-    args: {},
+  args: {},
 
-    play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
 
-        expect(onDoneResult(canvas)).toMatchObject({
-            count: 1,
-            onDoneResult: {
-                valid: true,
-                value: []
-            }
-        });
-    }
-};
+    expect(onDoneResult(canvas)).toMatchObject({
+      count: 1,
+      onDoneResult: {
+        valid: true,
+        value: [],
+      },
+    })
+  },
+}
 
 export const onDoneTest = {
-    args: {
-        type: "most",
-        intro: "Of the issues you thought were Least important, please give a brief explanation of why it's important for everyone to consider it",
-        shared: {
-            mosts: [point1, point2],
-            leasts: [point3],
-            whyMosts: [point1, point2],
-            whyLeasts: [point3],
-        }
+  args: {
+    type: 'most',
+    intro:
+      "Of the issues you thought were Least important, please give a brief explanation of why it's important for everyone to consider it",
+    shared: {
+      mosts: [point1, point2],
+      leasts: [point3],
+      whyMosts: [point1, point2],
+      whyLeasts: [point3],
     },
-    play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
-        const subjectEle = canvas.getAllByPlaceholderText(/type some thing here/i);
-        const descriptionEle = canvas.getAllByPlaceholderText(/description/i);
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const subjectEle = canvas.getAllByPlaceholderText(/type some thing here/i)
+    const descriptionEle = canvas.getAllByPlaceholderText(/description/i)
 
-        // fill in the first point subject and description
-        await userEvent.type(subjectEle[0], 'This is the first subject!');
-        await userEvent.tab();
-        await userEvent.type(descriptionEle[0], 'This is the first description!');
-        await userEvent.tab();
+    // fill in the first point subject and description
+    await userEvent.type(subjectEle[0], 'This is the first subject!')
+    await userEvent.tab()
+    await userEvent.type(descriptionEle[0], 'This is the first description!')
+    await userEvent.tab()
 
-        // fill in the second point subject and description
-        await userEvent.type(subjectEle[1], 'This is the second subject!');
-        await userEvent.tab();
-        await userEvent.type(descriptionEle[1], 'This is the second description!');
-        await userEvent.tab();
+    // fill in the second point subject and description
+    await userEvent.type(subjectEle[1], 'This is the second subject!')
+    await userEvent.tab()
+    await userEvent.type(descriptionEle[1], 'This is the second description!')
+    await userEvent.tab()
 
-        expect(onDoneResult(canvas)).toMatchObject({
-            count: 5,
-            onDoneResult: {
-                valid: true,
-                value: [
-                    {
-                        "_id": "1",
-                        "subject": "Point 1",
-                        "description": "Point 1 Description",
-                        "children": {
-                            "type": {
-                                "displayName": "WithStyles(DemInfo)",
-                                "defaultProps": {},
-                                "__docgenInfo": {
-                                    "description": "",
-                                    "methods": [],
-                                    "displayName": "DemInfo"
-                                }
-                            },
-                            "key": null,
-                            "ref": null,
-                            "props": {
-                                "user": {
-                                    "dob": "1990-10-20T00:00:00.000Z",
-                                    "state": "NY",
-                                    "party": "Independent"
-                                }
-                            },
-                            "_owner": null,
-                            "_store": {}
-                        },
-                        "valid": true,
-                        "answerSubject": "This is the first subject!",
-                        "answerDescription": "This is the first description!"
-                    },
-                    {
-                        "_id": "2",
-                        "subject": "Point 2",
-                        "description": "Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ",
-                        "children": {
-                            "type": {
-                                "displayName": "WithStyles(DemInfo)",
-                                "defaultProps": {},
-                                "__docgenInfo": {
-                                    "description": "",
-                                    "methods": [],
-                                    "displayName": "DemInfo"
-                                }
-                            },
-                            "key": null,
-                            "ref": null,
-                            "props": {
-                                "user": {
-                                    "dob": "1980-10-20T00:00:00.000Z",
-                                    "state": "GA",
-                                    "party": "Independent"
-                                }
-                            },
-                            "_owner": null,
-                            "_store": {}
-                        },
-                        "valid": true,
-                        "answerSubject": "This is the second subject!",
-                        "answerDescription": "This is the second description!"
-                    },
-                ]
-            }
-        });
-    }
-};
+    expect(onDoneResult(canvas)).toMatchObject({
+      count: 5,
+      onDoneResult: {
+        valid: true,
+        value: [
+          {
+            _id: '1',
+            subject: 'Point 1',
+            description: 'Point 1 Description',
+            children: {
+              type: {
+                displayName: 'WithStyles(DemInfo)',
+                defaultProps: {},
+                __docgenInfo: {
+                  description: '',
+                  methods: [],
+                  displayName: 'DemInfo',
+                },
+              },
+              key: null,
+              ref: null,
+              props: {
+                user: {
+                  dob: '1990-10-20T00:00:00.000Z',
+                  state: 'NY',
+                  party: 'Independent',
+                },
+              },
+              _owner: null,
+              _store: {},
+            },
+            valid: true,
+            answerSubject: 'This is the first subject!',
+            answerDescription: 'This is the first description!',
+          },
+          {
+            _id: '2',
+            subject: 'Point 2',
+            description:
+              'Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, Point 2 Description, ',
+            children: {
+              type: {
+                displayName: 'WithStyles(DemInfo)',
+                defaultProps: {},
+                __docgenInfo: {
+                  description: '',
+                  methods: [],
+                  displayName: 'DemInfo',
+                },
+              },
+              key: null,
+              ref: null,
+              props: {
+                user: {
+                  dob: '1980-10-20T00:00:00.000Z',
+                  state: 'GA',
+                  party: 'Independent',
+                },
+              },
+              _owner: null,
+              _store: {},
+            },
+            valid: true,
+            answerSubject: 'This is the second subject!',
+            answerDescription: 'This is the second description!',
+          },
+        ],
+      },
+    })
+  },
+}


### PR DESCRIPTION
This change refactors the Point and PointGroup components, namely:

- Passed a Point obj to the Point component instead of subject/description/etc.
- Rendered demInfo from Point instead of passing it in as a child.
- Assigned default prop values vState = 'default' and children = [].
- Changed stories to pass in a point/create point objs. with demInfo instead of user property.
- Renamed pointObj variables to pointDoc to disambiguate from Point component. 
- PointGroup takes Point instead of pointObj as well, and renders children just as Point does. 