### PR TITLE
Transparent navbar#182

### DIFF
--- a/app/components/top-nav-bar.jsx
+++ b/app/components/top-nav-bar.jsx
@@ -1,6 +1,6 @@
 // https://github.com/EnCiv/civil-pursuit/issues/52
-
 // https://github.com/EnCiv/civil-pursuit/issues/144
+// https://github.com/EnCiv/civil-pursuit/issues/182
 
 'use strict'
 
@@ -188,15 +188,40 @@ const TopNavBar = props => {
 // Define the styles using the theme object
 const useStylesFromThemeFunction = createUseStyles(theme => ({
   colors: props => ({
-    color: props.mode === 'dark' ? 'white' : theme.colors.darkModeGray,
+    color: (() => {
+      if (props.mode === 'dark' || props.mode === 'transparent') {
+        return 'white'
+      } else if (props.mode === 'light') {
+        return theme.colors.lightModeColor
+      } else {
+        return theme.colors.darkModeGray
+      }
+    })(),
   }),
   topNavBar: props => ({
     width: '100%',
+    position: () => {
+      if (props.mode === 'transparent') {
+        return 'absolute'
+      } else {
+        return ''
+      }
+    },
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
     fontSize: '1rem',
-    backgroundColor: props.mode === 'dark' ? theme.colors.darkModeGray : 'white',
+    backgroundColor: (() => {
+      if (props.mode === 'dark') {
+        return theme.colors.darkModeGray
+      } else if (props.mode === 'light') {
+        return theme.colors.lightModeColor
+      } else if (props.mode === 'transparent') {
+        return 'transparent'
+      } else {
+        return 'white'
+      }
+    })(),
   }),
 
   columnAligner: props => ({
@@ -222,6 +247,7 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
     position: 'relative',
   },
   logo: {
+    zIndex: 1,
     width: '8.5rem',
     height: 'auto',
     paddingBottom: '1.5rem',
@@ -244,9 +270,11 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
     },
   },
   mobileMenuContainer: props => ({
+    padding: '1.25rem 1.25rem',
     display: 'flex',
     width: '80%',
-    background: props.mode === 'dark' ? theme.colors.darkModeGray : theme.colors.encivYellow,
+    background:
+      props.mode === 'dark' || props.mode === 'transparent' ? theme.colors.darkModeGray : theme.colors.encivYellow,
     flexDirection: 'column',
     justifyContent: 'left',
     [`@media (min-width: ${theme.condensedWidthBreakPoint})`]: {
@@ -269,7 +297,7 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
     },
     '&:hover': {
       background: theme.colors.encivYellow,
-      color: props.mode === 'dark' ? 'black' : 'white',
+      color: props.mode === 'dark' || props.mode === 'transparent' ? 'black' : 'white',
     },
     '&:focus': {
       outline: `${theme.focusOutline}`,
@@ -283,7 +311,7 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
     cursor: 'default',
     background: 'none',
     border: 'none',
-    padding: '0 0 1rem 0',
+    padding: '0.5rem',
     margin: '0',
     whiteSpace: 'nowrap',
     [`@media (max-width: ${theme.condensedWidthBreakPoint})`]: {
@@ -322,7 +350,7 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
     textAlign: 'left',
     '&:hover': {
       background: theme.colors.encivYellow,
-      color: props.mode === 'dark' ? 'black' : 'white',
+      color: props.mode === 'dark' || props.mode === 'transparent' ? 'black' : 'white',
     },
     '&:focus': {
       outline: `${theme.focusOutline}`,
@@ -336,13 +364,13 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
     cursor: 'pointer',
     background: 'none',
     border: 'none',
-    padding: '0 0 1rem 0',
+    padding: '0.5rem',
     margin: '0',
     whiteSpace: 'nowrap',
     textAlign: 'left',
     '&:hover': {
       background: theme.colors.encivYellow,
-      color: props.mode === 'dark' ? 'black' : 'white',
+      color: props.mode === 'dark' || props.mode === 'transparent' ? 'black' : 'white',
     },
     '&:focus': {
       outline: `${theme.focusOutline}`,
@@ -364,7 +392,17 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
     width: '15%',
     height: 'auto',
     fontSize: '1.5rem',
-    background: props.mode === 'dark' ? theme.colors.darkModeGray : 'white',
+    background: (() => {
+      if (props.mode === 'dark') {
+        return theme.colors.darkModeGray
+      } else if (props.mode === 'light') {
+        return theme.colors.lightModeColor
+      } else if (props.mode === 'transparent') {
+        return 'transparent'
+      } else {
+        return 'white'
+      }
+    })(),
     border: 'none',
     display: 'flex',
     justifyContent: 'center',
@@ -374,7 +412,7 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
     },
     '&:hover': {
       background: theme.colors.encivYellow,
-      color: props.mode === 'dark' ? 'black' : 'white',
+      color: props.mode === 'dark' || props.mode === 'transparent' ? 'black' : 'white',
     },
   }),
   menuList: {

--- a/app/components/top-nav-bar.jsx
+++ b/app/components/top-nav-bar.jsx
@@ -200,13 +200,13 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
   }),
   topNavBar: props => ({
     width: '100%',
-    position: () => {
+    position: (() => {
       if (props.mode === 'transparent') {
         return 'absolute'
       } else {
         return ''
       }
-    },
+    })(),
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',

--- a/app/components/top-nav-bar.jsx
+++ b/app/components/top-nav-bar.jsx
@@ -200,6 +200,7 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
   }),
   topNavBar: props => ({
     width: '100%',
+    zIndex: theme.zIndexes.menu, // The navbar appears below other blocks without zIndex
     position: (() => {
       if (props.mode === 'transparent') {
         return 'absolute'
@@ -247,7 +248,6 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
     position: 'relative',
   },
   logo: {
-    zIndex: 1,
     width: '8.5rem',
     height: 'auto',
     paddingBottom: '1.5rem',
@@ -264,7 +264,6 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
     gap: '0.4rem',
     transform: 'translateX(-50%)',
     alignItems: 'baseline',
-    zIndex: theme.zIndexes.menu,
     [`@media (max-width: ${theme.condensedWidthBreakPoint})`]: {
       display: 'none',
     },

--- a/stories/top-nav-bar.stories.jsx
+++ b/stories/top-nav-bar.stories.jsx
@@ -38,6 +38,10 @@ export default {
     viewport: {
       viewports: INITIAL_VIEWPORTS,
     },
+    backgrounds: {
+      default: 'gray',
+      values: [{ name: 'gray', value: '#808080' }],
+    },
   },
 }
 
@@ -165,6 +169,25 @@ export const DarkModeMobile = {
   args: {
     menu: menuArray,
     mode: 'dark',
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphonex',
+    },
+  },
+}
+
+export const TransparentMode = {
+  args: {
+    menu: menuArray,
+    mode: 'transparent',
+  },
+}
+
+export const TransparentMobileMode = {
+  args: {
+    menu: menuArray,
+    mode: 'transparent',
   },
   parameters: {
     viewport: {


### PR DESCRIPTION
This change adds a transparent mode to the top-nav-bar, which also makes the navbar absolutely positioned so elements can display behind it, and fixes padding in the mobile menu to improve spacing. 

Part of the changes are included in https://github.com/EnCiv/enciv-home/pull/57