### PR TITLE
Fixed warnings in ranking component

### DIFF
--- a/app/components/ranking.jsx
+++ b/app/components/ranking.jsx
@@ -42,6 +42,8 @@ export default function Ranking(props) {
         `Unhandled rank selection: ${e.target.value}. Please pass a handler function via the onDone prop.`
       )
     } else onDone({ valid: true, value: e.target.value })
+    console.log(onDone);
+
   }
   return (
     <div
@@ -52,7 +54,7 @@ export default function Ranking(props) {
     >
       {responseOptions.map(option => {
         return (
-          <label>
+          <label key={option}>
             <input
               disabled={disabled || false}
               checked={response === option}
@@ -60,6 +62,7 @@ export default function Ranking(props) {
               value={option}
               name={`importance-${option}`}
               className={cx(styleClasses.hideDefaultRadio, `ranking${option}`)}
+              onChange={() =>onSelectionChange(option)}
             ></input>
             <span className={cx(styleClasses.option)}>
               <svg

--- a/app/components/ranking.jsx
+++ b/app/components/ranking.jsx
@@ -42,14 +42,12 @@ export default function Ranking(props) {
         `Unhandled rank selection: ${e.target.value}. Please pass a handler function via the onDone prop.`
       )
     } else onDone({ valid: true, value: e.target.value })
-    console.log(onDone);
-
+   
   }
   return (
     <div
       data-value={response}
       className={cx(className, styleClasses.group, disabled && styleClasses.disabled)}
-      onChange={onSelectionChange}
       {...otherProps}
     >
       {responseOptions.map(option => {
@@ -62,7 +60,7 @@ export default function Ranking(props) {
               value={option}
               name={`importance-${option}`}
               className={cx(styleClasses.hideDefaultRadio, `ranking${option}`)}
-              onChange={() =>onSelectionChange(option)}
+              onChange={onSelectionChange}
             ></input>
             <span className={cx(styleClasses.option)}>
               <svg


### PR DESCRIPTION
Hello @ddfridley, I have updated the below changes. 

- key={option}: Uniquely identifies each element in the list, preventing React warnings about missing keys.
- onChange={() => onSelectionChange(option)}: Triggers onSelectionChange with the specific option selected.