### PR TITLE
Fix: Adjust Next button dimensions to match Figma design (#259)

### DIFF
--- a/app/components/step-footer.jsx
+++ b/app/components/step-footer.jsx
@@ -1,4 +1,6 @@
 //https://github.com/EnCiv/civil-pursuit/issues/51
+//https://github.com/EnCiv/civil-pursuit/issues/259
+
 import React from 'react'
 import { createUseStyles } from 'react-jss'
 import { TextButton, PrimaryButton } from './button.jsx'
@@ -60,6 +62,13 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
   },
   next: {
     margin: '1rem 2rem',
+    width: '100%',                 // Flexible width based on parent
+    maxWidth: '13.8125rem',        // Ensures it doesn't exceed the design width
+    height: '3.125rem',
+    padding: '0.5rem 1.25rem',
+    borderRadius: '0.5rem',
+    border: `2px solid ${theme.colorPrimary}`,
+    textAlign: 'center',            
   },
 }))
 export default StepFooter


### PR DESCRIPTION
What Changed
- Updated the "Next" button styles in the `StepFooter` component to match the Figma design.
- Made the button responsive by using `rem` units and flexible width.

Key Changes:
- Width: Set to `100%` with a `max-width` of `13.8125rem` (221px).
- Height: Fixed at `3.125rem` (50px).
- Padding: Adjusted to `0.5rem 1.25rem` for internal spacing.
- Border Radius: Rounded corners with `0.5rem`.
- Border: Added a `2px solid` border using the theme's primary color.

Why It Was Changed
- To align the button's dimensions with the Figma design and ensure responsiveness across layouts.