### PR TITLE
fixed tournament#260

### DIFF
--- a/app/components/tournament.js
+++ b/app/components/tournament.js
@@ -72,7 +72,7 @@ function Tournament(props) {
 
   return (
     <div className={cx(classes.wrapper, className)} {...otherProps}>
-      <RoundTracker roundsStatus={['complete', 'complete', 'inProgress', 'pending', 'pending']} />
+      <RoundTracker className={classes.roundTracker} roundsStatus={['complete', 'complete', 'inProgress', 'pending', 'pending']} />
       <StepSlider
         key={state.currentRound}
         steps={stepInfo}
@@ -88,6 +88,9 @@ function Tournament(props) {
 const useStylesFromThemeFunction = createUseStyles(theme => ({
   wrapper: {
     width: '100%',
+  },
+  roundTracker: {
+    marginBottom: '59px',
   },
 }))
 

--- a/app/components/tournament.js
+++ b/app/components/tournament.js
@@ -90,7 +90,7 @@ const useStylesFromThemeFunction = createUseStyles(theme => ({
     width: '100%',
   },
   roundTracker: {
-    marginBottom: '59px',
+    marginBottom: '3.6875rem',
   },
 }))
 


### PR DESCRIPTION
Successfully added spacing between progress and steps.


Before
![Xnip2025-01-15_23-45-05](https://github.com/user-attachments/assets/9065d946-3d70-4bd3-8c2c-6a8d031f09c6)
After
![Xnip2025-01-15_23-45-29](https://github.com/user-attachments/assets/e305dddd-f350-4ea9-867e-67e77481144c)
